### PR TITLE
Make Auth Error NSError-ish

### DIFF
--- a/Sources/FirebaseAuth/FIRAuthTokenResult.swift
+++ b/Sources/FirebaseAuth/FIRAuthTokenResult.swift
@@ -25,7 +25,7 @@ public struct AuthTokenResult {
     // The JWT should have three components
     guard components.count == 3 else {
       throw NSError(domain: "com.google.firebase.auth",
-                    code: AuthErrorCode.FIRAuthErrorCode.malformedJWT.rawValue,
+                    code: AuthErrorCode.malformedJWT.rawValue,
                     userInfo: [NSLocalizedDescriptionKey:"Failed to decode token"])
     }
 
@@ -39,7 +39,7 @@ public struct AuthTokenResult {
     guard let data = Data(base64Encoded: payload,
                           options: .ignoreUnknownCharacters) else {
       throw NSError(domain: "com.google.firebase.auth",
-                    code: AuthErrorCode.FIRAuthErrorCode.malformedJWT.rawValue,
+                    code: AuthErrorCode.malformedJWT.rawValue,
                     userInfo: [NSLocalizedDescriptionKey:"Failed to decode token payload"])
     }
 
@@ -49,7 +49,7 @@ public struct AuthTokenResult {
         try? JSONSerialization.jsonObject(with: data, options: options)
             as? [String:Any] else {
       throw NSError(domain: "com.google.firebase.auth",
-                    code: AuthErrorCode.FIRAuthErrorCode.malformedJWT.rawValue,
+                    code: AuthErrorCode.malformedJWT.rawValue,
                     userInfo: [NSLocalizedDescriptionKey:"Failed to deserialise token payload"])
     }
 
@@ -60,7 +60,7 @@ public struct AuthTokenResult {
           let expirationDate = contents["exp"] as? TimeInterval,
           let issueDate = contents["iat"] as? TimeInterval else {
       throw NSError(domain: "com.google.firebase.auth",
-                    code: AuthErrorCode.FIRAuthErrorCode.malformedJWT.rawValue,
+                    code: AuthErrorCode.malformedJWT.rawValue,
                     userInfo: [NSLocalizedDescriptionKey:"Missing fields in token payload"])
     }
 

--- a/Sources/FirebaseAuth/FIRAuthTokenResult.swift
+++ b/Sources/FirebaseAuth/FIRAuthTokenResult.swift
@@ -25,7 +25,7 @@ public struct AuthTokenResult {
     // The JWT should have three components
     guard components.count == 3 else {
       throw NSError(domain: "com.google.firebase.auth",
-                    code: AuthError.Code.malformedJWT.rawValue,
+                    code: AuthErrorCode.FIRAuthErrorCode.malformedJWT.rawValue,
                     userInfo: [NSLocalizedDescriptionKey:"Failed to decode token"])
     }
 
@@ -39,7 +39,7 @@ public struct AuthTokenResult {
     guard let data = Data(base64Encoded: payload,
                           options: .ignoreUnknownCharacters) else {
       throw NSError(domain: "com.google.firebase.auth",
-                    code: AuthError.Code.malformedJWT.rawValue,
+                    code: AuthErrorCode.FIRAuthErrorCode.malformedJWT.rawValue,
                     userInfo: [NSLocalizedDescriptionKey:"Failed to decode token payload"])
     }
 
@@ -49,7 +49,7 @@ public struct AuthTokenResult {
         try? JSONSerialization.jsonObject(with: data, options: options)
             as? [String:Any] else {
       throw NSError(domain: "com.google.firebase.auth",
-                    code: AuthError.Code.malformedJWT.rawValue,
+                    code: AuthErrorCode.FIRAuthErrorCode.malformedJWT.rawValue,
                     userInfo: [NSLocalizedDescriptionKey:"Failed to deserialise token payload"])
     }
 
@@ -60,7 +60,7 @@ public struct AuthTokenResult {
           let expirationDate = contents["exp"] as? TimeInterval,
           let issueDate = contents["iat"] as? TimeInterval else {
       throw NSError(domain: "com.google.firebase.auth",
-                    code: AuthError.Code.malformedJWT.rawValue,
+                    code: AuthErrorCode.FIRAuthErrorCode.malformedJWT.rawValue,
                     userInfo: [NSLocalizedDescriptionKey:"Missing fields in token payload"])
     }
 

--- a/Sources/FirebaseAuth/FirebaseAuthError.swift
+++ b/Sources/FirebaseAuth/FirebaseAuthError.swift
@@ -2,93 +2,95 @@
 
 import Foundation
 
-public struct AuthErrorCode: Error {
-  public enum FIRAuthErrorCode: Int {
-    case invalidCustomToken = 17000
-    case customTokenMismatch = 17002
-    case invalidCredential = 17004
-    case userDisabled = 17005
-    case operationNotAllowed = 17006
-    case emailAlreadyInUse = 17007
-    case invalidEmail = 17008
-    case wrongPassword = 17009
-    case tooManyRequests = 17010
-    case userNotFound = 17011
-    case accountExistsWithDifferentCredential = 17012
-    case requiresRecentLogin = 17014
-    case providerAlreadyLinked = 17015
-    case noSuchProvider = 17016
-    case invalidUserToken = 17017
-    case networkError = 17020
-    case userTokenExpired = 17021
-    case invalidAPIKey = 17023
-    case userMismatch = 17024
-    case credentialAlreadyInUse = 17025
-    case weakPassword = 17026
-    case appNotAuthorized = 17028
-    case expiredActionCode = 17029
-    case invalidActionCode = 17030
-    case invalidMessagePayload = 17031
-    case invalidSender = 17032
-    case invalidRecipientEmail = 17033
-    case missingEmail = 17034
-    case missingIosBundleID = 17036
-    case missingAndroidPackageName = 17037
-    case unauthorizedDomain = 17038
-    case invalidContinueURI = 17039
-    case missingContinueURI = 17040
-    case missingPhoneNumber = 17041
-    case invalidPhoneNumber = 17042
-    case missingVerificationCode = 17043
-    case invalidVerificationCode = 17044
-    case missingVerificationID = 17045
-    case invalidVerificationID = 17046
-    case missingAppCredential = 17047
-    case invalidAppCredential = 17048
-    case sessionExpired = 17051
-    case quotaExceeded = 17052
-    case missingAppToken = 17053
-    case notificationNotForwarded = 17054
-    case appNotVerified = 17055
-    case captchaCheckFailed = 17056
-    case webContextAlreadyPresented = 17057
-    case webContextCancelled = 17058
-    case appVerificationUserInteractionFailure = 17059
-    case invalidClientID = 17060
-    case webNetworkRequestFailed = 17061
-    case webInternalError = 17062
-    case webSignInUserInteractionFailure = 17063
-    case localPlayerNotAuthenticated = 17066
-    case nullUser = 17067
-    case dynamicLinkNotActivated = 17068
-    case invalidProviderID = 17071
-    case tenantIDMismatch = 17072
-    case unsupportedTenantOperation = 17073
-    case invalidDynamicLinkDomain = 17074
-    case rejectedCredential = 17075
-    case gameKitNotLinked = 17076
-    case secondFactorRequired = 17078
-    case missingMultiFactorSession = 17081
-    case missingMultiFactorInfo = 17082
-    case invalidMultiFactorSession = 17083
-    case multiFactorInfoNotFound = 17084
-    case adminRestrictedOperation = 17085
-    case unverifiedEmail = 17086
-    case secondFactorAlreadyEnrolled = 17087
-    case maximumSecondFactorCountExceeded = 17088
-    case unsupportedFirstFactor = 17089
-    case emailChangeNeedsVerification = 17090
-    case missingOrInvalidNonce = 17094
-    case blockingCloudFunctionError = 17105
-    case missingClientIdentifier = 17993
-    case keychainError = 17995
-    case internalError = 17999
-    case malformedJWT = 18000
-  }
+public enum AuthErrorCode: Int {
+  case invalidCustomToken = 17000
+  case customTokenMismatch = 17002
+  case invalidCredential = 17004
+  case userDisabled = 17005
+  case operationNotAllowed = 17006
+  case emailAlreadyInUse = 17007
+  case invalidEmail = 17008
+  case wrongPassword = 17009
+  case tooManyRequests = 17010
+  case userNotFound = 17011
+  case accountExistsWithDifferentCredential = 17012
+  case requiresRecentLogin = 17014
+  case providerAlreadyLinked = 17015
+  case noSuchProvider = 17016
+  case invalidUserToken = 17017
+  case networkError = 17020
+  case userTokenExpired = 17021
+  case invalidAPIKey = 17023
+  case userMismatch = 17024
+  case credentialAlreadyInUse = 17025
+  case weakPassword = 17026
+  case appNotAuthorized = 17028
+  case expiredActionCode = 17029
+  case invalidActionCode = 17030
+  case invalidMessagePayload = 17031
+  case invalidSender = 17032
+  case invalidRecipientEmail = 17033
+  case missingEmail = 17034
+  case missingIosBundleID = 17036
+  case missingAndroidPackageName = 17037
+  case unauthorizedDomain = 17038
+  case invalidContinueURI = 17039
+  case missingContinueURI = 17040
+  case missingPhoneNumber = 17041
+  case invalidPhoneNumber = 17042
+  case missingVerificationCode = 17043
+  case invalidVerificationCode = 17044
+  case missingVerificationID = 17045
+  case invalidVerificationID = 17046
+  case missingAppCredential = 17047
+  case invalidAppCredential = 17048
+  case sessionExpired = 17051
+  case quotaExceeded = 17052
+  case missingAppToken = 17053
+  case notificationNotForwarded = 17054
+  case appNotVerified = 17055
+  case captchaCheckFailed = 17056
+  case webContextAlreadyPresented = 17057
+  case webContextCancelled = 17058
+  case appVerificationUserInteractionFailure = 17059
+  case invalidClientID = 17060
+  case webNetworkRequestFailed = 17061
+  case webInternalError = 17062
+  case webSignInUserInteractionFailure = 17063
+  case localPlayerNotAuthenticated = 17066
+  case nullUser = 17067
+  case dynamicLinkNotActivated = 17068
+  case invalidProviderID = 17071
+  case tenantIDMismatch = 17072
+  case unsupportedTenantOperation = 17073
+  case invalidDynamicLinkDomain = 17074
+  case rejectedCredential = 17075
+  case gameKitNotLinked = 17076
+  case secondFactorRequired = 17078
+  case missingMultiFactorSession = 17081
+  case missingMultiFactorInfo = 17082
+  case invalidMultiFactorSession = 17083
+  case multiFactorInfoNotFound = 17084
+  case adminRestrictedOperation = 17085
+  case unverifiedEmail = 17086
+  case secondFactorAlreadyEnrolled = 17087
+  case maximumSecondFactorCountExceeded = 17088
+  case unsupportedFirstFactor = 17089
+  case emailChangeNeedsVerification = 17090
+  case missingOrInvalidNonce = 17094
+  case blockingCloudFunctionError = 17105
+  case missingClientIdentifier = 17993
+  case keychainError = 17995
+  case internalError = 17999
+  case malformedJWT = 18000
+}
 
-  public var code: FIRAuthErrorCode
-
-  public init(code: FIRAuthErrorCode) {
-    self.code = code
+extension AuthErrorCode: Error {}
+extension AuthErrorCode {
+  // This allows us to re-expose self as a code similarly
+  // to what the Firebase SDK does when it creates the
+  // underlying NSErrors on iOS/macOS.
+  public var code: AuthErrorCode {
+    return self
   }
 }

--- a/Sources/FirebaseAuth/FirebaseAuthError.swift
+++ b/Sources/FirebaseAuth/FirebaseAuthError.swift
@@ -2,14 +2,8 @@
 
 import Foundation
 
-public struct AuthError {
-}
-
-extension AuthError: Error {
-}
-
-extension AuthError {
-  public enum Code: Int {
+public struct AuthErrorCode: Error {
+  public enum FIRAuthErrorCode: Int {
     case invalidCustomToken = 17000
     case customTokenMismatch = 17002
     case invalidCredential = 17004
@@ -90,5 +84,11 @@ extension AuthError {
     case keychainError = 17995
     case internalError = 17999
     case malformedJWT = 18000
+  }
+
+  public var code: FIRAuthErrorCode
+
+  public init(code: FIRAuthErrorCode) {
+    self.code = code
   }
 }


### PR DESCRIPTION
Internally, the Firebase SDK uses some Objective-C → Swift magic with `NS_ERROR_ENUM` to generate a bunch of NSErrors which will get bridges into Swift, so it expects some of those functions to be there as if it were an NSError.

Unfortunately they give this NSError a Swift type that's a little confusing with `NS_SWIFT_NAME(AuthErrorCode)` so our error object is actually called `AuthErrorCode` which we need to match.