### PR TITLE
Create Auth State Listener API

### DIFF
--- a/Examples/FireBaseUI/FireBaseUIViewController.swift
+++ b/Examples/FireBaseUI/FireBaseUIViewController.swift
@@ -73,10 +73,21 @@ internal final class FireBaseUIViewController: ViewController {
     Label(frame: .init(x: btnCreate.frame.minX, y: btnReset.frame.maxY, width: view.frame.width - 16, height: 400))
   }()
 
+  var authStateListenerHandle: AuthStateDidChangeListenerHandle?
+
   override func viewDidLoad() {
     super.viewDidLoad()
     self.title = "FireBase UI"
     configureView()
+
+    authStateListenerHandle = Auth.auth().addStateDidChangeListener { auth, user in
+      print(
+      """
+      Auth State Changed!
+      Auth: \(String(describing: auth))
+      User: \(String(describing: user))
+      """)
+    }
 
     if let user = Auth.auth().currentUser {
       txtEmail.text = user.email
@@ -252,5 +263,11 @@ internal final class FireBaseUIViewController: ViewController {
       return
     }
     firestoreTestingWindow.makeKeyAndVisible()
+  }
+
+  deinit {
+    if let handle = authStateListenerHandle {
+      Auth.auth().removeStateDidChangeListener(handle)
+    }
   }
 }

--- a/Sources/FirebaseAuth/AuthStateDidChangeListenerHandle.swift
+++ b/Sources/FirebaseAuth/AuthStateDidChangeListenerHandle.swift
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+@_exported
+import firebase
+
+import CxxShim
+
+internal typealias ApplicationAuthStateListenerPointer = UnsafeMutablePointer<firebase.auth.AuthStateListener>
+
+/// A mostly opaque type to manage the lifetime of the escaping closure and auth listener C++ class required
+/// from the Auth api's `addStateDidChangeListener`.
+///
+/// This is also used in the `removeStateDidChangeListener` to deregister the internal listener pointer when
+/// the calling code need to unsubscribe from these updates.
+public class AuthStateDidChangeListenerHandle {
+  /// The boxed version of the callback that was passed in from the Swift caller that we will retain in this object.
+  private let callback: Unmanaged<AnyObject>
+
+  /// An internal reference to the actual Firebase listener that we must hold onto.
+  internal let listener: ApplicationAuthStateListenerPointer
+
+  /// Initialize a new handle with a boxed closure and a pointer to the Firebase Auth listener.
+  /// - Parameters:
+  ///   - callback: A boxed Swift closure that will be kept alive for the lifetime of this class.
+  ///   - listener: A pointer to a C++ AuthStateListener that must be retained for the lifetime of this class.
+  internal init(_ callback: Unmanaged<AnyObject>, _ listener: ApplicationAuthStateListenerPointer) {
+    self.callback = callback
+    self.listener = listener
+  }
+}

--- a/Sources/firebase/include/FirebaseAuth.hh
+++ b/Sources/firebase/include/FirebaseAuth.hh
@@ -29,11 +29,40 @@ user_provider_id(const ::firebase::auth::User &user) noexcept {
   return user.provider_id();
 }
 
-inline std::string
-user_uid(const ::firebase::auth::User &user) noexcept {
+inline std::string user_uid(const ::firebase::auth::User &user) noexcept {
   return user.uid();
 }
+
+typedef void (*AuthStateListenerCallback)(::firebase::auth::Auth *auth,
+                                          ::firebase::auth::User *user,
+                                          void *user_data);
+
+class ApplicationAuthStateListener
+    : public ::firebase::auth::AuthStateListener {
+public:
+  ApplicationAuthStateListener(AuthStateListenerCallback initial_callback,
+                               void *initial_data)
+      : callback(initial_callback), user_data(initial_data) {}
+
+  void OnAuthStateChanged(::firebase::auth::Auth *auth) override {
+    ::firebase::auth::User user = auth->current_user();
+    callback(auth, &user, user_data);
+  }
+
+private:
+  AuthStateListenerCallback callback;
+  void *user_data;
+};
+
+/// @brief Allocate an auth listener on the heap and return it configured with the passed in parameters.
+/// @param callback This is the callback that you would like to run whenever Firebase tells us that auth has changed, typically you will construct this inline with the function call.
+/// @param user_data This can be used to serialize a Swift closure into so that you can pull it back out when `callback` is run.
+/// @return A heap-allocated auth listener.
+inline ::firebase::auth::AuthStateListener *
+create_auth_state_listener(AuthStateListenerCallback callback,
+                           void *user_data) {
+  return new ApplicationAuthStateListener(callback, user_data);
 }
+} // namespace swift_firebase::swift_cxx_shims::firebase::auth
 
 #endif
-


### PR DESCRIPTION
This adds the add and remove APIs for auth state listener. Should fix WPP-727.

We've had to allocate our custom subclass on the heap since we want to make it appear as if this type is actually the base `AuthStateListener` instead of our subclass' type. This is important since you will be unable to actually register the listener with the Firebase Auth API unless Swift's interop can figure out that it _is_ an `AuthStateListener`.

Additionally, we've opted to keep the API that requires explicit de-registration of a listener handler, it's a little annoying (since we could also de-register when our opaque type de-initializes) but though it was better to have a 1:1 mapping from the what the underlying SDK expects and what we're providing to the Swift consumer.