### PR TITLE
FirebaseAuth: improve `Auth.addStateDidChangeListener(_:)`

### DIFF
--- a/Sources/FirebaseAuth/AuthStateDidChangeListenerHandle.swift
+++ b/Sources/FirebaseAuth/AuthStateDidChangeListenerHandle.swift
@@ -5,26 +5,26 @@ import firebase
 
 import CxxShim
 
-internal typealias ApplicationAuthStateListenerPointer = UnsafeMutablePointer<firebase.auth.AuthStateListener>
+public typealias AuthStateDidChangeListenerHandle = AnyObject
 
-/// A mostly opaque type to manage the lifetime of the escaping closure and auth listener C++ class required
-/// from the Auth api's `addStateDidChangeListener`.
-///
-/// This is also used in the `removeStateDidChangeListener` to deregister the internal listener pointer when
-/// the calling code need to unsubscribe from these updates.
-public class AuthStateDidChangeListenerHandle {
+internal class _AuthStateDidChangeListenerHandle {
   /// The boxed version of the callback that was passed in from the Swift caller that we will retain in this object.
   private let callback: Unmanaged<AnyObject>
 
   /// An internal reference to the actual Firebase listener that we must hold onto.
-  internal let listener: ApplicationAuthStateListenerPointer
+  internal var listener: UnsafeMutablePointer<firebase.auth.AuthStateListener>
 
-  /// Initialize a new handle with a boxed closure and a pointer to the Firebase Auth listener.
-  /// - Parameters:
-  ///   - callback: A boxed Swift closure that will be kept alive for the lifetime of this class.
-  ///   - listener: A pointer to a C++ AuthStateListener that must be retained for the lifetime of this class.
-  internal init(_ callback: Unmanaged<AnyObject>, _ listener: ApplicationAuthStateListenerPointer) {
-    self.callback = callback
-    self.listener = listener
+  internal init(_ body: @escaping (Auth, User?) -> Void) {
+    self.callback = Unmanaged.passRetained(body as AnyObject)
+    self.listener = swift_firebase.swift_cxx_shims.firebase.auth.AuthStateListener.Create({ auth, user, callback in
+      guard let auth else { return }
+      if let callback, let body = Unmanaged<AnyObject>.fromOpaque(callback).takeUnretainedValue() as? ((Auth, User?) -> Void) {
+        body(auth, user.pointee.is_valid() ? user.pointee : nil)
+      }
+    }, UnsafeMutableRawPointer(self.callback.toOpaque()))
+  }
+
+  deinit {
+    swift_firebase.swift_cxx_shims.firebase.auth.AuthStateListener.Destroy(UnsafeMutableRawPointer(self.listener))
   }
 }

--- a/Sources/FirebaseAuth/FirebaseAuth+Swift.swift
+++ b/Sources/FirebaseAuth/FirebaseAuth+Swift.swift
@@ -210,22 +210,14 @@ extension Auth {
 
   public func addStateDidChangeListener(_ listener: @escaping (Auth, User?) -> Void)
       -> AuthStateDidChangeListenerHandle {
-    let boxed = Unmanaged.passRetained(listener as AnyObject)
-
-    let listenerPointer: ApplicationAuthStateListenerPointer = swift_firebase.swift_cxx_shims.firebase.auth.create_auth_state_listener({ auth , user, callback in
-      if let callback, let listener =  Unmanaged<AnyObject>.fromOpaque(callback).takeUnretainedValue() as? ((Auth, User?) -> Void) {
-        guard let auth else { return }
-        listener(auth, user.pointee.is_valid() ? user.pointee : nil)
-      }
-    }, UnsafeMutableRawPointer(boxed.toOpaque()))
-
-    self.pointee.AddAuthStateListener(listenerPointer)
-
-    return AuthStateDidChangeListenerHandle(boxed, listenerPointer)
+    let handle = _AuthStateDidChangeListenerHandle(listener)
+    self.pointee.AddAuthStateListener(handle.listener)
+    return handle
   }
 
   public func removeStateDidChangeListener(_ listenerHandle: AuthStateDidChangeListenerHandle) {
-    self.pointee.RemoveAuthStateListener(listenerHandle.listener)
+    guard let handle = listenerHandle as? _AuthStateDidChangeListenerHandle else { return }
+    self.pointee.RemoveAuthStateListener(handle.listener)
   }
 
   // public func addIDTokenDidChangeListener(_ listener: @escaping (Auth, User?) -> Void)


### PR DESCRIPTION
The reference implementation declares
`AuthStateDidChangeListenerHandler` to be the following:

~~~
public typealias AuthStateDidChangeListenerHandler = NSObjectProtocol
~~~

This most closely resembles `AnyObject`.  Use implicit conversion to make the handle fully opaque.

Rename the subclassed type identically to the base type as the namespace disambiguates the types.  This type exists solely to provide a default method implementation for the pure virtual call of `OnAuthStateChanged`.

As the address of this value is significant, ensure that the type is marked as a non-copyable, non-assignable, immovable type.  Doing so will remove the ability of the Swift C++ importer to import the type (which is why we have the factory method for the type).  Indicate that the type is an unsafe reference type (we must handle the lifetime of the object ourselves).

Sink the factory method into the type as `Create`.  Introduce the associated destructor method `Destroy` to avoid a memory leak.  Due to the type being a reference type, we cannot easily pass the natively typed pointer to the method (it will pass by reference).  The alternative is to provide an instance method to `delete this`.  That is sometimes done in the dtors, but can be confusing so prefer to use the `static` method instead.

Finally, as the address is important, create the wrapped callback in the handle itself to avoid the shuffling of the pointer.  We now create the callable object inside the handle directly and release it in the `deinit` of the handle.  This allows us to immediately see the lifetime semantics of the unsafe pointer.

While tweaking this area, hoist a `guard` statement further to avoid the casting in the case that we will not use the result anyway.