### PR TITLE
Implement setData function

### DIFF
--- a/Sources/FirebaseFirestore/DocumentReference+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentReference+Swift.swift
@@ -79,8 +79,9 @@ extension DocumentReference {
       withUnsafePointer(to: continuation) { continuation in
         future.OnCompletion_SwiftWorkaround({ future, pvContinuation in
           let pContinuation = pvContinuation?.assumingMemoryBound(to: Promise.self)
-          // Since this returns void, we only need to care about the error state
-          if future.pointee.error() != 0 {
+          if future.pointee.error() == 0 {
+            pContinuation.pointee.resume()
+          } else {
             let code = future.pointee.error()
             let message = String(cString: future.pointee.__error_messageUnsafe()!)
             pContinuation.pointee.resume(throwing: FirebaseError(code: code, message: message))

--- a/Sources/FirebaseFirestore/FirestoreDataConverter.swift
+++ b/Sources/FirebaseFirestore/FirestoreDataConverter.swift
@@ -93,9 +93,9 @@ internal struct FirestoreDataConverter {
       guard let array = field as? Array<Any> else { return nil }
       var vector = swift_firebase.swift_cxx_shims.firebase.firestore.FirestoreFieldValues()
 
-      for thing in array {
-        guard let item = firestoreValue(field: thing) else { continue }
-        vector.push_back(item)
+      for element in array {
+        guard let value = firestoreValue(field: element) else { continue }
+        vector.push_back(value)
       }
 
       return firebase.firestore.FieldValue.Array(vector)

--- a/Sources/FirebaseFirestore/FirestoreDataConverter.swift
+++ b/Sources/FirebaseFirestore/FirestoreDataConverter.swift
@@ -50,7 +50,7 @@ internal struct FirestoreDataConverter {
   ///
   /// - Parameter document: The dictionary that describes the document of data you'd like to create.
   /// - Returns: a `MapFieldValue` with converted types that Firestore will understand.
-  static func firestoreValue(document: [String: Any]) -> firebase.firestore.MapFieldValue {
+  internal static func firestoreValue(document: [String: Any]) -> firebase.firestore.MapFieldValue {
     var map = firebase.firestore.MapFieldValue()
     for item in document {
       guard let value = firestoreValue(field: item.value) else { continue }
@@ -63,7 +63,7 @@ internal struct FirestoreDataConverter {
   /// Converts Swift values to their corresponding Firestore `FieldValue`s.
   /// - Parameter field: A Swift value you'd like to convert into a `FieldValue`
   /// - Returns: The `FieldValue` or `nil` that is the Firestore analog of the passed in value.
-  static func firestoreValue(field: Any) -> firebase.firestore.FieldValue? {
+  internal static func firestoreValue(field: Any) -> firebase.firestore.FieldValue? {
     switch field.self {
     case is NSNull:
       return firebase.firestore.FieldValue.Null()

--- a/Sources/FirebaseFirestore/FirestoreDataConverter.swift
+++ b/Sources/FirebaseFirestore/FirestoreDataConverter.swift
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 import Foundation
 
-struct FirestoreDataConverter {
+import Cxx
+
+internal struct FirestoreDataConverter {
   static func value(workaround: swift_firebase.swift_cxx_shims.firebase.firestore.MapFieldValue_Workaround) -> [String: Any]? {
     guard workaround.keys.size() == workaround.values.size() else { return nil }
 
@@ -38,6 +40,75 @@ struct FirestoreDataConverter {
       let value = swift_firebase.swift_cxx_shims.firebase.firestore.field_value_workaround(field.map_value())
       assert(value.keys.size() == value.values.size())
       return Dictionary(uniqueKeysWithValues: zip(value.keys, value.values).lazy)
+    default:
+      return nil
+    }
+  }
+
+  /// Maps a Swift version of a Firestore document into a `MapFieldValue` as expected by the
+  /// Firestore set and update functions.
+  ///
+  /// - Parameter document: The dictionary that describes the document of data you'd like to create.
+  /// - Returns: a `MapFieldValue` with converted types that Firestore will understand.
+  static func firestoreValue(document: [String: Any]) -> firebase.firestore.MapFieldValue {
+    var map = firebase.firestore.MapFieldValue()
+    for item in document {
+      guard let value = firestoreValue(field: item.value) else { continue }
+      map[std.string(item.key)] = value
+    }
+
+    return map
+  }
+
+  /// Converts Swift values to their corresponding Firestore `FieldValue`s.
+  /// - Parameter field: A Swift value you'd like to convert into a `FieldValue`
+  /// - Returns: The `FieldValue` or `nil` that is the Firestore analog of the passed in value.
+  static func firestoreValue(field: Any) -> firebase.firestore.FieldValue? {
+    switch field.self {
+    case is NSNull:
+      return firebase.firestore.FieldValue.Null()
+    case is Bool:
+      guard let bool = field as? Bool else { return nil }
+      return firebase.firestore.FieldValue.Boolean(bool)
+    case is Int:
+      guard let int = field as? Int64 else { return nil }
+      return firebase.firestore.FieldValue.Integer(int)
+    case is Double:
+      guard let double = field as? Double else { return nil }
+      return firebase.firestore.FieldValue.Double(double)
+    case is Date:
+      guard let date = field as? Date else { return nil }
+      return firebase.firestore.FieldValue.Timestamp(date.firestoreTimestamp())
+    case is String:
+      guard let string = field as? String else { return nil }
+      return firebase.firestore.FieldValue.String(std.string(string))
+    case is Data:
+      guard let data = field as? Data else { return nil }
+      let size = data.count
+      return firebase.firestore.FieldValue.Blob([UInt8](data), size)
+    case is GeoPoint:
+      guard let geopoint = field as? GeoPoint else { return nil }
+      return firebase.firestore.FieldValue.GeoPoint(geopoint)
+    case is Array<Any>:
+      guard let array = field as? Array<Any> else { return nil }
+      var vector = swift_firebase.swift_cxx_shims.firebase.firestore.FirestoreFieldValues()
+
+      for thing in array {
+        guard let item = firestoreValue(field: thing) else { continue }
+        vector.push_back(item)
+      }
+
+      return firebase.firestore.FieldValue.Array(vector)
+    case is Dictionary<String, Any>:
+      guard let dictionary = field as? [String: Any] else { return nil }
+
+      var map = firebase.firestore.MapFieldValue()
+      for item in dictionary {
+        guard let value = firestoreValue(field: item.value) else { continue }
+        map[std.string(item.key)] = value
+      }
+
+      return firebase.firestore.FieldValue.Map(map)
     default:
       return nil
     }

--- a/Sources/FirebaseFirestore/Timestamp+Swift.swift
+++ b/Sources/FirebaseFirestore/Timestamp+Swift.swift
@@ -8,19 +8,7 @@ private let NanoSecondsPerSecond = 1_000_000_000
 
 extension Timestamp {
   public init(date: Date) {
-    var secondsDouble: Double = 0.0
-    var fraction = modf(date.timeIntervalSince1970, &secondsDouble)
-
-    // Re-implementation of https://github.com/firebase/firebase-ios-sdk/blob/master/Firestore/Source/API/FIRTimestamp.m#L50
-    if (fraction < 0) {
-      fraction += 1.0;
-      secondsDouble -= 1.0;
-    }
-
-    let seconds = Int64(secondsDouble)
-    let nanoseconds = Int32(fraction * Double(NanoSecondsPerSecond))
-
-    self = Timestamp(seconds: seconds, nanoseconds: nanoseconds)
+    self = date.firestoreTimestamp()
   }
 
   public init(seconds: Int64, nanoseconds: Int32) {
@@ -54,5 +42,23 @@ extension Timestamp: Codable {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(seconds(), forKey: .seconds)
     try container.encode(nanoseconds(), forKey: .nanoseconds)
+  }
+}
+
+extension Date {
+  internal func firestoreTimestamp() -> Timestamp {
+    var secondsDouble: Double = 0.0
+    var fraction = modf(timeIntervalSince1970, &secondsDouble)
+
+    // Re-implementation of https://github.com/firebase/firebase-ios-sdk/blob/master/Firestore/Source/API/FIRTimestamp.m#L50
+    if (fraction < 0) {
+      fraction += 1.0;
+      secondsDouble -= 1.0;
+    }
+
+    let seconds = Int64(secondsDouble)
+    let nanoseconds = Int32(fraction * Double(NanoSecondsPerSecond))
+
+    return Timestamp(seconds, nanoseconds)
   }
 }

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -10,21 +10,25 @@
 // these functions will go away whenever possible.
 namespace swift_firebase::swift_cxx_shims::firebase::firestore {
 inline ::firebase::firestore::Settings
-firestore_settings(::firebase::firestore::Firestore* firestore) {
+firestore_settings(::firebase::firestore::Firestore *firestore) {
   return firestore->settings();
 }
 
 inline ::firebase::firestore::DocumentReference
-firestore_document(::firebase::firestore::Firestore* firestore, const ::std::string &document_path) {
+firestore_document(::firebase::firestore::Firestore *firestore,
+                   const ::std::string &document_path) {
   return firestore->Document(document_path);
 }
 
 inline ::firebase::firestore::CollectionReference
-firestore_collection(::firebase::firestore::Firestore* firestore, const ::std::string &collection_path) {
+firestore_collection(::firebase::firestore::Firestore *firestore,
+                     const ::std::string &collection_path) {
   return firestore->Collection(collection_path);
 }
 
-inline ::firebase::firestore::Firestore*
+// MARK: - DocumentReference
+
+inline ::firebase::firestore::Firestore *
 document_firestore(::firebase::firestore::DocumentReference document) {
   return document.firestore();
 }
@@ -40,9 +44,20 @@ document_path(const ::firebase::firestore::DocumentReference document) {
 }
 
 inline ::firebase::Future<::firebase::firestore::DocumentSnapshot>
-document_get(const ::firebase::firestore::DocumentReference document, ::firebase::firestore::Source source = ::firebase::firestore::Source::kDefault) {
+document_get(const ::firebase::firestore::DocumentReference document,
+             ::firebase::firestore::Source source =
+                 ::firebase::firestore::Source::kDefault) {
   return document.Get(source);
 }
+
+inline ::firebase::Future<void>
+document_set_data(::firebase::firestore::DocumentReference document,
+                  const ::firebase::firestore::MapFieldValue data,
+                  const ::firebase::firestore::SetOptions options) {
+  return document.Set(data, options);
+}
+
+// MARK: - DocumentSnapshot
 
 inline ::firebase::firestore::DocumentReference
 snapshot_reference(const ::firebase::firestore::DocumentSnapshot snapshot) {
@@ -55,8 +70,8 @@ struct MapFieldValue_Workaround {
   std::vector<::firebase::firestore::FieldValue> values;
 };
 
-inline MapFieldValue_Workaround
-map_field_value_to_workaround(const ::firebase::firestore::MapFieldValue value) {
+inline MapFieldValue_Workaround map_field_value_to_workaround(
+    const ::firebase::firestore::MapFieldValue value) {
   MapFieldValue_Workaround data;
   data.keys.reserve(value.size());
   data.values.reserve(value.size());
@@ -69,9 +84,10 @@ map_field_value_to_workaround(const ::firebase::firestore::MapFieldValue value) 
   return std::move(data);
 }
 
-inline MapFieldValue_Workaround
-snapshot_get_data_workaround(const ::firebase::firestore::DocumentSnapshot snapshot,
-                  const ::firebase::firestore::DocumentSnapshot::ServerTimestampBehavior stb) {
+inline MapFieldValue_Workaround snapshot_get_data_workaround(
+    const ::firebase::firestore::DocumentSnapshot snapshot,
+    const ::firebase::firestore::DocumentSnapshot::ServerTimestampBehavior
+        stb) {
   auto snap = snapshot.GetData(stb);
 
   return map_field_value_to_workaround(snap);
@@ -84,41 +100,39 @@ field_value_workaround(::firebase::firestore::MapFieldValue value) {
 #endif
 
 inline ::firebase::firestore::DocumentReference
-collection_document(::firebase::firestore::CollectionReference collection, std::string document_path) {
+collection_document(::firebase::firestore::CollectionReference collection,
+                    std::string document_path) {
   return collection.Document(document_path);
 }
 
-typedef void (*SnapshotListenerTypedCallback_SwiftWorkaround) (const ::firebase::firestore::DocumentSnapshot *snapshot,
-                                                               ::firebase::firestore::Error error_code,
-                                                               const char *error_message,
-                                                               void *user_data
-                                                               );
+typedef void (*SnapshotListenerTypedCallback_SwiftWorkaround)(
+    const ::firebase::firestore::DocumentSnapshot *snapshot,
+    ::firebase::firestore::Error error_code, const char *error_message,
+    void *user_data);
 inline ::firebase::firestore::ListenerRegistration
 document_add_snapshot_listener(
-  ::firebase::firestore::DocumentReference document,
-  SnapshotListenerTypedCallback_SwiftWorkaround callback,
-  void *user_data
-  ) {
-    return document.AddSnapshotListener([callback, user_data](const ::firebase::firestore::DocumentSnapshot &snapshot, ::firebase::firestore::Error error_code, const std::string &error_message) {
-      callback(
-        &snapshot,
-        error_code,
-        error_message.c_str(),
-        user_data
-      );
-    });
+    ::firebase::firestore::DocumentReference document,
+    SnapshotListenerTypedCallback_SwiftWorkaround callback, void *user_data) {
+  return document.AddSnapshotListener(
+      [callback,
+       user_data](const ::firebase::firestore::DocumentSnapshot &snapshot,
+                  ::firebase::firestore::Error error_code,
+                  const std::string &error_message) {
+        callback(&snapshot, error_code, error_message.c_str(), user_data);
+      });
 }
 
-inline void
-listener_registration_remove(::firebase::firestore::ListenerRegistration registration) {
+inline void listener_registration_remove(
+    ::firebase::firestore::ListenerRegistration registration) {
   registration.Remove();
 }
 
-const uint8_t*
-field_get_blob(const ::firebase::firestore::FieldValue field) {
+const uint8_t *field_get_blob(const ::firebase::firestore::FieldValue field) {
   return field.blob_value();
 }
 
-} // swift_firebase::swift_cxx_shims::firebase::firestore
+typedef std::vector<::firebase::firestore::FieldValue> FirestoreFieldValues;
+
+} // namespace swift_firebase::swift_cxx_shims::firebase::firestore
 
 #endif


### PR DESCRIPTION
This implements the `setData` function as a simple async function which can optionally take in a boolean value describing whether or not the fields should be merged with the document or not.

This does not supply the `setData<T: Encodable>(from: T)` as that will come from a different PR. 