### PR TITLE
Pass reference to remove optimizations

### DIFF
--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -15,12 +15,12 @@ firestore_settings(::firebase::firestore::Firestore* firestore) {
 }
 
 inline ::firebase::firestore::DocumentReference
-firestore_document(::firebase::firestore::Firestore* firestore, const ::std::string document_path) {
+firestore_document(::firebase::firestore::Firestore* firestore, const ::std::string &document_path) {
   return firestore->Document(document_path);
 }
 
 inline ::firebase::firestore::CollectionReference
-firestore_collection(::firebase::firestore::Firestore* firestore, const ::std::string collection_path) {
+firestore_collection(::firebase::firestore::Firestore* firestore, const ::std::string &collection_path) {
   return firestore->Collection(collection_path);
 }
 


### PR DESCRIPTION
We likely should have always been passing a reference here, but it seems that updates to the underlying C++ runtime have created new opportunities for optimizations that weren't present which cause breakage when passing by value.