### PR TITLE
Getting a snapshot should be nullable

### DIFF
--- a/Examples/FireBaseUI/FirestoreTestingViewController.swift
+++ b/Examples/FireBaseUI/FirestoreTestingViewController.swift
@@ -68,7 +68,7 @@ internal final class FirestoreTestingViewController: ViewController {
       let document = Firestore.firestore().document(path)
       do {
         let snapshot = try await document.get()
-        await displayData(data: snapshot.debugDescription)
+        await displayData(data: snapshot?.debugDescription ?? "No snapshot")
       } catch {
         await displayError(error: error)
       }

--- a/Sources/FirebaseFirestore/DocumentReference+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentReference+Swift.swift
@@ -29,7 +29,7 @@ extension DocumentReference {
     String(swift_firebase.swift_cxx_shims.firebase.firestore.document_path(self))
   }
 
-  public func get() async throws -> DocumentSnapshot {
+  public func get() async throws -> DocumentSnapshot? {
     typealias Promise = CheckedContinuation<UnsafeMutablePointer<firebase.firestore.DocumentSnapshot>, any Error>
     let snapshot = try await withCheckedThrowingContinuation { (continuation: Promise) in
       let future = swift_firebase.swift_cxx_shims.firebase.firestore.document_get(self, .default)
@@ -48,7 +48,7 @@ extension DocumentReference {
       future.Wait(firebase.FutureBase.kWaitTimeoutInfinite)
     }
 
-    return snapshot.pointee
+    return snapshot.pointee.is_valid() ? snapshot.pointee : nil
   }
 
   public func addSnapshotListener(_ listener: @escaping SnapshotListenerCallback) -> ListenerRegistration {


### PR DESCRIPTION
 We need to ensure that when successfully fetching a document that
    doesn't exist, rather than getting back a document, you get back nil. We
    were simply returning the value before checking if it was valid to do
    so. This adds the check on whether or not it's a valid document before
    returning it back to the caller.