### PR TITLE
Ensure a snapshot exists before returning it

### DIFF
--- a/Sources/FirebaseFirestore/DocumentReference+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentReference+Swift.swift
@@ -48,7 +48,7 @@ extension DocumentReference {
       future.Wait(firebase.FutureBase.kWaitTimeoutInfinite)
     }
 
-    return snapshot.pointee.is_valid() ? snapshot.pointee : nil
+    return snapshot.pointee.exists && snapshot.pointee.is_valid() ? snapshot.pointee : nil
   }
 
   public func addSnapshotListener(_ listener: @escaping SnapshotListenerCallback) -> ListenerRegistration {

--- a/Sources/FirebaseFirestore/DocumentReference+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentReference+Swift.swift
@@ -48,7 +48,8 @@ extension DocumentReference {
       future.Wait(firebase.FutureBase.kWaitTimeoutInfinite)
     }
 
-    return snapshot.pointee.exists && snapshot.pointee.is_valid() ? snapshot.pointee : nil
+    guard snapshot.pointee.exists else { return nil }
+    return snapshot.pointee.is_valid() ? snapshot.pointee : nil
   }
 
   public func addSnapshotListener(_ listener: @escaping SnapshotListenerCallback) -> ListenerRegistration {

--- a/Sources/FirebaseFirestore/DocumentSnapshot+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentSnapshot+Swift.swift
@@ -21,6 +21,10 @@ extension DocumentSnapshot {
     swift_firebase.swift_cxx_shims.firebase.firestore.snapshot_reference(self)
   }
 
+  public var exists: Bool {
+    swift_firebase.swift_cxx_shims.firebase.firestore.snapshot_exists(self)
+  }
+
   public func data(with behavior: ServerTimestampBehavior) -> [String: Any]? {
     let data = swift_firebase.swift_cxx_shims.firebase.firestore.snapshot_get_data_workaround(self, behavior)
     return FirestoreDataConverter.value(workaround: data)

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -64,6 +64,11 @@ snapshot_reference(const ::firebase::firestore::DocumentSnapshot snapshot) {
   return snapshot.reference();
 }
 
+inline bool
+snapshot_exists(const ::firebase::firestore::DocumentSnapshot snapshot) {
+  return snapshot.exists();
+}
+
 #if SR69711
 struct MapFieldValue_Workaround {
   std::vector<std::string> keys;
@@ -101,7 +106,7 @@ field_value_workaround(::firebase::firestore::MapFieldValue value) {
 
 inline ::firebase::firestore::DocumentReference
 collection_document(::firebase::firestore::CollectionReference collection,
-                    std::string &document_path) {
+                    std::string document_path) {
   return collection.Document(document_path);
 }
 

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -106,7 +106,7 @@ field_value_workaround(::firebase::firestore::MapFieldValue value) {
 
 inline ::firebase::firestore::DocumentReference
 collection_document(::firebase::firestore::CollectionReference collection,
-                    std::string document_path) {
+                    std::string &document_path) {
   return collection.Document(document_path);
 }
 

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -65,7 +65,7 @@ snapshot_reference(const ::firebase::firestore::DocumentSnapshot snapshot) {
 }
 
 inline bool
-snapshot_exists(const ::firebase::firestore::DocumentSnapshot snapshot) {
+snapshot_exists(const ::firebase::firestore::DocumentSnapshot &snapshot) {
   return snapshot.exists();
 }
 


### PR DESCRIPTION
The Firebase SDK always creates a `DocumentSnapshot` and returns it when you call into the get APIs, we need to ensure we call `exists` which was pointed out when we filed this issue https://github.com/firebase/firebase-cpp-sdk/issues/1493#issuecomment-1828444320. 