### PR TITLE
document_path should be const

### DIFF
--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -106,7 +106,7 @@ field_value_workaround(::firebase::firestore::MapFieldValue value) {
 
 inline ::firebase::firestore::DocumentReference
 collection_document(::firebase::firestore::CollectionReference collection,
-                    std::string &document_path) {
+                    const ::std::string &document_path) {
   return collection.Document(document_path);
 }
 


### PR DESCRIPTION
`document_path` should likely have always been const since it's never going to change once you pass it in. This also fixes the build breakage that anyone using the tip of HEAD might experience.