### PR TITLE
Move the snapshot callback to the main queue

### DIFF
--- a/Sources/FirebaseFirestore/DocumentReference+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentReference+Swift.swift
@@ -64,6 +64,12 @@ extension DocumentReference {
           // We only return a snapshot if the error code isn't 0 (aka the 'ok' error code)
           let returned = error == nil ? snapshot?.pointee : nil
 
+          // Make sure we dispatch our callback back into the main thread to keep consistent
+          // with the reference API which will call back on the 'user_executor' which typically
+          // ends up being the main queue.
+          // Relevant code:
+          // - https://github.com/firebase/firebase-ios-sdk/blob/main/Firestore/Source/API/FIRFirestore.mm#L210-L218
+          // - https://github.com/firebase/firebase-ios-sdk/blob/main/Firestore/core/src/api/document_reference.cc#L236-L237
           DispatchQueue.main.async {
             callback(returned, error)
           }

--- a/Sources/FirebaseFirestore/DocumentReference+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentReference+Swift.swift
@@ -63,7 +63,10 @@ extension DocumentReference {
           let error = NSError.firestore(errorCode)
           // We only return a snapshot if the error code isn't 0 (aka the 'ok' error code)
           let returned = error == nil ? snapshot?.pointee : nil
-          callback(returned, error)
+
+          DispatchQueue.main.async {
+            callback(returned, error)
+          }
         }
       }, UnsafeMutableRawPointer(boxed.toOpaque()))
 


### PR DESCRIPTION
Through analyzing the Firebase Cocoa code, we've realized the the snapshot listener code path seems to get executed on a 'user executor' which typically means the main queue. We didn't have a similar model in our code and it seems like it could cause us issues in code that is making assumption on what thread this code is running on.