### PR TITLE
Fix swift-win32 package version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,9 @@ let SwiftFirebase =
               .executable(name: "FireBaseUI", targets: ["FireBaseUI"]),
             ],
             dependencies: [
-              .package(url: "https://github.com/compnerd/swift-win32", branch: "main"),
+              // This revision is important since it's the first one before the swift-win32 repo moved to versioned symlinks
+              // for different swift-tools-versions.
+              .package(url: "https://github.com/compnerd/swift-win32", revision: "07e91e67e86f173743329c6753d9e66ac4727830"),
             ],
             targets: [
               .target(name: "firebase",


### PR DESCRIPTION
We should be using the version of `swift-win32` right before when versioned package files were introduced since there are issues with symlinks and package resolution