### PR TITLE
Add support for getting collection ref from doc ref

### DIFF
--- a/Sources/FirebaseFirestore/DocumentReference+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentReference+Swift.swift
@@ -25,6 +25,10 @@ extension DocumentReference {
     swift_firebase.swift_cxx_shims.firebase.firestore.document_firestore(self)!
   }
 
+  public func collection(_ path: String) -> CollectionReference {
+    swift_firebase.swift_cxx_shims.firebase.firestore.document_collection(self, std.string(path))
+  }
+
   public var path: String {
     String(swift_firebase.swift_cxx_shims.firebase.firestore.document_path(self))
   }

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -57,6 +57,12 @@ document_set_data(::firebase::firestore::DocumentReference document,
   return document.Set(data, options);
 }
 
+inline ::firebase::firestore::CollectionReference
+document_collection(::firebase::firestore::DocumentReference document,
+                    const ::std::string &collection_path) {
+  return document.Collection(collection_path);
+}
+
 // MARK: - DocumentSnapshot
 
 inline ::firebase::firestore::DocumentReference


### PR DESCRIPTION
This will allow to build paths to more complex data structures within firestore and is essential to land `FirebaseSidebarSyncModel` on Windows (prototype based on this PR: https://github.com/thebrowsercompany/arc/pull/22154).