### PR TITLE
Update README to reflect toolchain update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 third_party/
 Examples/FireBaseUI/Resources/google-services-desktop.json
 Package.resolved
+out/*

--- a/README.md
+++ b/README.md
@@ -12,11 +12,14 @@ As of 2023-08-10, the Firebase SDK requires some changes to support the Swift/C+
 
 ### Prerequisites
 
-0. Make sure you have the right Swift toolchain installed, currently this repo requires at least https://download.swift.org/development/windows10/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a/swift-DEVELOPMENT-SNAPSHOT-2023-08-12-a-windows10.exe to build.
-1. Download the lastest build of the Firebase C++ SDK from https://github.com/thebrowsercompany/firebase-cpp-sdk/tags, click on the tag and then download the pre-build artifacts. These will be called `firebase-windows-amd64.zip` or `firebase-windows-arm64.zip` depending on which architecture you'd like to build for.  
+0. Make sure you have a Swift toolchain that supports C++ interop.
+1. Download the lastest build of the Firebase C++ SDK from https://github.com/thebrowsercompany/firebase-cpp-sdk/tags, click on the tag and then download the pre-build artifacts. These will be called `firebase-windows-amd64.zip` or `firebase-windows-arm64.zip` depending on which architecture you'd like to build for.
 3. Run `md third_party\firebase-development` to create the directory where we will extract the Firebase C++ SDK release that was just downloaded
 4. Extract the Firebase C++ SDK release into the `third_party\firebase-development` directory that was just created.
 5. Modify the `Examples\FireBaseUI\Resources\google-services.json` file to include the correct values from Firebase.
+
+> [!TIP]
+> It can be useful to mark the `google-services.json` file as assumed unchanged so you don't accidentially check it in with real credentials. To do that, you can run the following: `git update-index --assume-unchanged .\Examples\FireBaseUI\Resources\google-services.json`
 
 ### Building
 


### PR DESCRIPTION
Internal toolchains are alread up to date and a specific one for BCNY
employees or external folks should no longer be necessary.

I also updated the gitignore to ignore the `out` folder if someone uses cmake.