### PR TITLE
Add support for DocumentChange

### DIFF
--- a/Sources/FirebaseFirestore/DocumentChange+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentChange+Swift.swift
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+@_exported
+import firebase
+@_spi(Error)
+import FirebaseCore
+
+import CxxShim
+import Foundation
+
+public typealias DocumentChange = firebase.firestore.DocumentChange
+public typealias DocumentChangeType = firebase.firestore.DocumentChange.`Type`
+
+extension DocumentChange {
+    public var type: DocumentChangeType {
+        swift_firebase.swift_cxx_shims.firebase.firestore.document_change_type(self)
+    }
+
+    public var document: DocumentSnapshot {
+        swift_firebase.swift_cxx_shims.firebase.firestore.document_change_document(self)
+    }
+
+    public var oldIndex: UInt {
+        UInt(swift_firebase.swift_cxx_shims.firebase.firestore.document_change_old_index(self))
+    }
+
+    public var newIndex: UInt {
+        UInt(swift_firebase.swift_cxx_shims.firebase.firestore.document_change_new_index(self))
+    }
+}

--- a/Sources/FirebaseFirestore/DocumentChange+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentChange+Swift.swift
@@ -2,11 +2,8 @@
 
 @_exported
 import firebase
-@_spi(Error)
-import FirebaseCore
 
 import CxxShim
-import Foundation
 
 public typealias DocumentChange = firebase.firestore.DocumentChange
 public typealias DocumentChangeType = firebase.firestore.DocumentChange.`Type`

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -144,6 +144,28 @@ const uint8_t *field_get_blob(const ::firebase::firestore::FieldValue field) {
 
 typedef std::vector<::firebase::firestore::FieldValue> FirestoreFieldValues;
 
+// MARK: - DocumentChange
+
+inline ::firebase::firestore::DocumentChange::Type
+document_change_type(const ::firebase::firestore::DocumentChange change) {
+  return change.type();
+}
+
+inline ::firebase::firestore::DocumentSnapshot
+document_change_document(const ::firebase::firestore::DocumentChange change) {
+  return change.document();
+}
+
+inline ::std::size_t
+document_change_old_index(const ::firebase::firestore::DocumentChange change) {
+  return change.old_index();
+}
+
+inline ::std::size_t
+document_change_new_index(const ::firebase::firestore::DocumentChange change) {
+  return change.new_index();
+}
+
 } // namespace swift_firebase::swift_cxx_shims::firebase::firestore
 
 #endif


### PR DESCRIPTION
Taking care to match the types defined by the ObjC API, including the use of `UInt` for `{old,new}Index` values and the definition of `DocumentChangeType`.