### PR TITLE
Expose FirestoreSource param through API

### DIFF
--- a/Sources/FirebaseFirestore/DocumentReference+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentReference+Swift.swift
@@ -34,8 +34,8 @@ extension DocumentReference {
   }
 
   // This variant is provided for compatibility with the ObjC API.
-  public func getDocument(completion: @escaping (DocumentSnapshot?, Error?) -> Void) {
-    let future = swift_firebase.swift_cxx_shims.firebase.firestore.document_get(self, .default)
+  public func getDocument(source: FirestoreSource = .default, completion: @escaping (DocumentSnapshot?, Error?) -> Void) {
+    let future = swift_firebase.swift_cxx_shims.firebase.firestore.document_get(self, source)
     future.setCompletion({
       let (snapshot, error) = future.resultAndError
       DispatchQueue.main.async {
@@ -44,9 +44,9 @@ extension DocumentReference {
     })
   }
 
-  public func getDocument() async throws -> DocumentSnapshot {
+  public func getDocument(source: FirestoreSource = .default) async throws -> DocumentSnapshot {
     try await withCheckedThrowingContinuation { continuation in
-      let future = swift_firebase.swift_cxx_shims.firebase.firestore.document_get(self, .default)
+      let future = swift_firebase.swift_cxx_shims.firebase.firestore.document_get(self, source)
       future.setCompletion({
         let (snapshot, error) = future.resultAndError
         if let error {

--- a/Sources/FirebaseFirestore/FirestoreSource+Swift.swift
+++ b/Sources/FirebaseFirestore/FirestoreSource+Swift.swift
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+@_exported
+import firebase
+
+public typealias FirestoreSource = firebase.firestore.Source
+
+extension FirestoreSource: @unchecked Sendable {}

--- a/Sources/FirebaseFirestore/Query+Swift.swift
+++ b/Sources/FirebaseFirestore/Query+Swift.swift
@@ -16,8 +16,8 @@ extension Query {
   }
 
   // This variant is provided for compatibility with the ObjC API.
-  public func getDocuments(completion: @escaping (QuerySnapshot?, Error?) -> Void) {
-    let future = swift_firebase.swift_cxx_shims.firebase.firestore.query_get(self, .default)
+  public func getDocuments(source: FirestoreSource = .default, completion: @escaping (QuerySnapshot?, Error?) -> Void) {
+    let future = swift_firebase.swift_cxx_shims.firebase.firestore.query_get(self, source)
     future.setCompletion({
       let (snapshot, error) = future.resultAndError
       DispatchQueue.main.async {
@@ -26,9 +26,9 @@ extension Query {
     })
   }
 
-  public func getDocuments() async throws -> QuerySnapshot {
+  public func getDocuments(source: FirestoreSource = .default) async throws -> QuerySnapshot {
     try await withCheckedThrowingContinuation { continuation in
-      let future = swift_firebase.swift_cxx_shims.firebase.firestore.query_get(self, .default)
+      let future = swift_firebase.swift_cxx_shims.firebase.firestore.query_get(self, source)
       future.setCompletion({
         let (snapshot, error) = future.resultAndError
         if let error {


### PR DESCRIPTION
Creates a simple typealias w/ Sendable conformance. The underlying type is just a C++ enum.