### PR TITLE
GHA: update to 2024-02-08 snapshot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         include:
           - branch: development
-            tag: DEVELOPMENT-SNAPSHOT-2023-08-10-a
+            tag: DEVELOPMENT-SNAPSHOT-2024-02-08-a
             options: -Xswiftc "-I${env:SDKROOT}\usr\lib\swift_static\windows"
 
     name: Swift ${{ matrix.tag }}


### PR DESCRIPTION
Update to a newer snapshot which is near the same point as the current Arc toolchain.