### PR TITLE
firebase: use bridging header and remove unnecessary header

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - branch: development
             tag: DEVELOPMENT-SNAPSHOT-2024-02-08-a
-            options: -Xswiftc "-I${env:SDKROOT}\usr\lib\swift_static\windows"
+            options: -Xswiftc "-I${env:SDKROOT}\usr\lib\swift_static\windows" -Xswiftc "-I${env:SDKROOT}\..\..\..\..\..\..\Toolchains\0.0.0+Asserts\usr\include"
 
     name: Swift ${{ matrix.tag }}
 

--- a/Sources/firebase/include/FirebaseCore.hh
+++ b/Sources/firebase/include/FirebaseCore.hh
@@ -3,7 +3,7 @@
 
 #include <firebase/util.h>
 
-#include <stdio.h>
+#include <swift/bridging>
 
 namespace swift_firebase::swift_cxx_shims::firebase {
 
@@ -14,7 +14,7 @@ typedef void (*FutureCompletionType)(void*);
 // Swift. We can ignore the `FutureBase` param as the Swift caller can just
 // retain the Future as part of its closure.
 template <class R>
-class __attribute__((swift_attr("conforms_to:FirebaseCore.FutureProtocol")))
+class SWIFT_CONFORMS_TO_PROTOCOL(FirebaseCore.FutureProtocol)
   Future : public ::firebase::Future<R> {
  public:
   typedef R ResultType;


### PR DESCRIPTION
The `stdio.h` is a C header, which should not be required. Prefer using the bridging header as that is available on newer toolchain releases.