### PR TITLE
GHA: remove obsolete workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - branch: development
             tag: DEVELOPMENT-SNAPSHOT-2024-02-08-a
-            options: -Xswiftc "-I${env:SDKROOT}\usr\lib\swift_static\windows" -Xswiftc "-I${env:SDKROOT}\..\..\..\..\..\..\Toolchains\0.0.0+Asserts\usr\include"
+            options: -Xswiftc "-I${env:SDKROOT}\..\..\..\..\..\..\Toolchains\0.0.0+Asserts\usr\include"
 
     name: Swift ${{ matrix.tag }}
 


### PR DESCRIPTION
The statically linked shims have been converted to dynamic linking upstream. This means that `swift_static` no longer contains anything and we do not need to add that module search path.