### PR TITLE
Implement runTransaction and batch support

### DIFF
--- a/Sources/FirebaseFirestore/Firestore+Swift.swift
+++ b/Sources/FirebaseFirestore/Firestore+Swift.swift
@@ -58,6 +58,10 @@ extension Firestore {
         // It is expected to run `updateBlock` on whatever thread this happens to be. This is
         // consistent with the behavior of the ObjC API as well.
 
+        // Since we could run `updateBlock` multiple times, we need to take care to reset any
+        // residue from previous runs. That means clearing out this error field.
+        context.error = nil
+
         withUnsafePointer(to: context.error) { pError in
           context.result = context.updateBlock(transaction!.pointee, pError)
         }

--- a/Sources/FirebaseFirestore/Firestore+Swift.swift
+++ b/Sources/FirebaseFirestore/Firestore+Swift.swift
@@ -50,6 +50,14 @@ extension Firestore {
       self, options ?? .init(), { transaction, pErrorMessage, pvUpdateBlock in
         let context = Unmanaged<AnyObject>.fromOpaque(pvUpdateBlock!).takeUnretainedValue() as! TransactionContext
 
+        // Instead of trying to relay the generated `NSError` through firebase's `Error` type
+        // and error message string, just store the `NSError` on `context` and access it later.
+        // We then only need to tell firebase if the update block succeeded or failed and can
+        // just not bother setting `pErrorMessage`.
+
+        // It is expected to run `updateBlock` on whatever thread this happens to be. This is
+        // consistent with the behavior of the ObjC API as well.
+
         withUnsafePointer(to: context.error) { pError in
           context.result = context.updateBlock(transaction!.pointee, pError)
         }
@@ -76,7 +84,7 @@ extension Firestore {
     }
   }
 
-  /*
+  /* TODO: Implement this.
   public func batch() -> WriteBatch {
   }
   */

--- a/Sources/FirebaseFirestore/Firestore+Swift.swift
+++ b/Sources/FirebaseFirestore/Firestore+Swift.swift
@@ -76,6 +76,10 @@ extension Firestore {
     })
   }
 
+  public func batch() -> WriteBatch {
+    swift_firebase.swift_cxx_shims.firebase.firestore.firestore_batch(self)
+  }
+
   private typealias TransactionUpdateBlock = (Transaction, UnsafePointer<NSError?>?) -> Any?
 
   private class TransactionContext {
@@ -87,11 +91,6 @@ extension Firestore {
       self.updateBlock = updateBlock
     }
   }
-
-  /* TODO: Implement this.
-  public func batch() -> WriteBatch {
-  }
-  */
 }
 
 // An extension that adds the encoder and decoder functions required

--- a/Sources/FirebaseFirestore/Firestore+Swift.swift
+++ b/Sources/FirebaseFirestore/Firestore+Swift.swift
@@ -80,14 +80,14 @@ extension Firestore {
     swift_firebase.swift_cxx_shims.firebase.firestore.firestore_batch(self)
   }
 
-  private typealias TransactionUpdateBlock = (Transaction, UnsafePointer<NSError?>?) -> Any?
-
   private class TransactionContext {
-    let updateBlock: TransactionUpdateBlock
+    typealias UpdateBlock = (Transaction, UnsafePointer<NSError?>?) -> Any?
+
+    let updateBlock: UpdateBlock
     var result: Any?
     var error: NSError?
 
-    init(updateBlock: @escaping TransactionUpdateBlock) {
+    init(updateBlock: @escaping UpdateBlock) {
       self.updateBlock = updateBlock
     }
   }

--- a/Sources/FirebaseFirestore/Firestore+Swift.swift
+++ b/Sources/FirebaseFirestore/Firestore+Swift.swift
@@ -47,14 +47,16 @@ extension Firestore {
     let context = TransactionContext(updateBlock: updateBlock)
     let boxed = Unmanaged.passRetained(context as AnyObject)
     let future = swift_firebase.swift_cxx_shims.firebase.firestore.firestore_run_transaction(
-      self, options, { transaction, pvUpdateBlock in
-        let context = Unmanaged<AnyObject>.fromOpaque(pvUpdateBlock!).takeUnretainedValue() as! TransactionContext
+      self, options ?? .init(), { transaction, pErrorMessage, pvUpdateBlock in
+        let _ = Unmanaged<AnyObject>.fromOpaque(pvUpdateBlock!).takeUnretainedValue() as! TransactionContext
 
-        context.result = context.updateBlock(transaction, nil)
+        //context.result = context.updateBlock(transaction, nil)
 
-        return 0 // XXX
+        //pErrorMessage.pointee.clear()
+
+        return 0 // firebase.firestore.kErrorNone
       },
-      UnsafeMutableRawPointer(boxed.toOpaque())
+      boxed.toOpaque()
     )
     future.setCompletion({
       completion(context.result, context.error)

--- a/Sources/FirebaseFirestore/NSError+FirestoreError.swift
+++ b/Sources/FirebaseFirestore/NSError+FirestoreError.swift
@@ -8,11 +8,18 @@ extension NSError {
   internal static func firestore(_ error: firebase.firestore.Error?, errorMessage: UnsafePointer<CChar>? = nil) -> NSError? {
     guard let actualError = error, actualError.rawValue != 0 else { return nil }
 
+    var errorMessageString: String?
+    if let errorMessage {
+      errorMessageString = .init(cString: errorMessage)
+    }
+    return firestore(actualError, errorMessage: errorMessageString)
+  }
+
+  internal static func firestore(_ error: firebase.firestore.Error, errorMessage: String?) -> NSError {
     var userInfo = [String: Any]()
     if let errorMessage {
-      userInfo[NSLocalizedDescriptionKey] = String(cString: errorMessage)
+      userInfo[NSLocalizedDescriptionKey] = errorMessage
     }
-
-    return NSError(domain: "firebase.firestore", code: Int(actualError.rawValue), userInfo: userInfo)
+    return NSError(domain: "firebase.firestore", code: Int(error.rawValue), userInfo: userInfo)
   }
 }

--- a/Sources/FirebaseFirestore/Transaction+Swift.swift
+++ b/Sources/FirebaseFirestore/Transaction+Swift.swift
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+@_exported
+import firebase
+
+import CxxShim
+
+public typealias Transaction = swift_firebase.swift_cxx_shims.firebase.firestore.TransactionWeakReference
+
+extension Transaction {
+  /*
+  public func setData(_ data: [String : Any], forDocument document: DocumentReference) -> Transaction {
+  }
+
+  public func setData(_ data: [String : Any], forDocument document: DocumentReference, merge: Bool) -> Transaction {
+  }
+
+  public func setData(_ data: [String : Any], forDocument document: DocumentReference, mergeFields: [Any]) -> Transaction {
+  }
+
+  public func updateData(_ fields: [AnyHashable : Any], forDocument document: DocumentReference) -> Transaction {
+  }
+
+  public func deleteDocument(_ document: DocumentReference) -> Transaction {
+  }
+
+  public func getDocument(_ document: DocumentReference) throws -> DocumentSnapshot {
+  }
+  */
+}

--- a/Sources/FirebaseFirestore/Transaction+Swift.swift
+++ b/Sources/FirebaseFirestore/Transaction+Swift.swift
@@ -14,6 +14,7 @@ extension Transaction {
   }
 
   public mutating func setData(_ data: [String : Any], forDocument document: DocumentReference, merge: Bool) -> Transaction {
+    assert(is_valid())
     self.Set(document, FirestoreDataConverter.firestoreValue(document: data), merge ? .Merge() : .init())
     return self
   }
@@ -24,16 +25,20 @@ extension Transaction {
   */
 
   public mutating func updateData(_ fields: [String : Any], forDocument document: DocumentReference) -> Transaction {
+    assert(is_valid())
     self.Update(document, FirestoreDataConverter.firestoreValue(document: fields))
     return self
   }
 
   public mutating func deleteDocument(_ document: DocumentReference) -> Transaction {
+    assert(is_valid())
     Delete(document)
     return self
   }
 
   public mutating func getDocument(_ document: DocumentReference) throws -> DocumentSnapshot {
+    assert(is_valid())
+
     var error = firebase.firestore.kErrorNone
     var errorMessage = std.string()
 

--- a/Sources/FirebaseFirestore/Transaction+Swift.swift
+++ b/Sources/FirebaseFirestore/Transaction+Swift.swift
@@ -4,27 +4,45 @@
 import firebase
 
 import CxxShim
+import Foundation
 
 public typealias Transaction = swift_firebase.swift_cxx_shims.firebase.firestore.TransactionWeakReference
 
 extension Transaction {
-  /*
-  public func setData(_ data: [String : Any], forDocument document: DocumentReference) -> Transaction {
+  public mutating func setData(_ data: [String : Any], forDocument document: DocumentReference) -> Transaction {
+    setData(data, forDocument: document, merge: false)
   }
 
-  public func setData(_ data: [String : Any], forDocument document: DocumentReference, merge: Bool) -> Transaction {
+  public mutating func setData(_ data: [String : Any], forDocument document: DocumentReference, merge: Bool) -> Transaction {
+    self.Set(document, FirestoreDataConverter.firestoreValue(document: data), merge ? .Merge() : .init())
+    return self
   }
 
-  public func setData(_ data: [String : Any], forDocument document: DocumentReference, mergeFields: [Any]) -> Transaction {
-  }
-
-  public func updateData(_ fields: [AnyHashable : Any], forDocument document: DocumentReference) -> Transaction {
-  }
-
-  public func deleteDocument(_ document: DocumentReference) -> Transaction {
-  }
-
-  public func getDocument(_ document: DocumentReference) throws -> DocumentSnapshot {
+  /* TODO: implement
+  public mutating func setData(_ data: [String : Any], forDocument document: DocumentReference, mergeFields: [Any]) -> Transaction {
   }
   */
+
+  public mutating func updateData(_ fields: [String : Any], forDocument document: DocumentReference) -> Transaction {
+    self.Update(document, FirestoreDataConverter.firestoreValue(document: fields))
+    return self
+  }
+
+  public mutating func deleteDocument(_ document: DocumentReference) -> Transaction {
+    Delete(document)
+    return self
+  }
+
+  public mutating func getDocument(_ document: DocumentReference) throws -> DocumentSnapshot {
+    var error = firebase.firestore.kErrorNone
+    var errorMessage = std.string()
+
+    let snapshot = Get(document, &error, &errorMessage)
+
+    if error != firebase.firestore.kErrorNone {
+      throw NSError.firestore(error, errorMessage: String(errorMessage))
+    }
+
+    return snapshot
+  }
 }

--- a/Sources/FirebaseFirestore/TransactionOptions+Swift.swift
+++ b/Sources/FirebaseFirestore/TransactionOptions+Swift.swift
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+@_exported
+import firebase
+
+public typealias TransactionOptions = firebase.firestore.TransactionOptions
+
+extension TransactionOptions {
+  public var maxAttempts: Int {
+    get {
+      Int(max_attempts())
+    }
+    set {
+      set_max_attempts(Int32(newValue))
+    }
+  }
+}

--- a/Sources/FirebaseFirestore/WriteBatch+Swift.swift
+++ b/Sources/FirebaseFirestore/WriteBatch+Swift.swift
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+@_exported
+import firebase
+
+public typealias WriteBatch = firebase.firestore.WriteBatch

--- a/Sources/FirebaseFirestore/WriteBatch+Swift.swift
+++ b/Sources/FirebaseFirestore/WriteBatch+Swift.swift
@@ -2,5 +2,66 @@
 
 @_exported
 import firebase
+@_spi(FirebaseInternal)
+import FirebaseCore
+
+import CxxShim
+import Foundation
 
 public typealias WriteBatch = firebase.firestore.WriteBatch
+
+extension WriteBatch {
+  public mutating func setData(_ data: [String : Any], forDocument document: DocumentReference) -> WriteBatch {
+    setData(data, forDocument: document, merge: false)
+  }
+
+  public mutating func setData(_ data: [String : Any], forDocument document: DocumentReference, merge: Bool) -> WriteBatch {
+    _ = swift_firebase.swift_cxx_shims.firebase.firestore.write_batch_set(
+      self, document, FirestoreDataConverter.firestoreValue(document: data), merge ? .Merge() : .init()
+    )
+    return self
+  }
+
+  /* TODO: implement
+  public mutating func setData(_ data: [String : Any], forDocument document: DocumentReference, mergeFields: [Any]) -> WriteBatch {
+  }
+  */
+
+  public mutating func updateData(_ fields: [String : Any], forDocument document: DocumentReference) -> WriteBatch {
+    _ = swift_firebase.swift_cxx_shims.firebase.firestore.write_batch_update(
+      self, document, FirestoreDataConverter.firestoreValue(document: fields)
+    )
+    return self
+  }
+
+  public mutating func deleteDocument(_ document: DocumentReference) -> WriteBatch {
+    _ = swift_firebase.swift_cxx_shims.firebase.firestore.write_batch_delete(
+      self, document
+    )
+    return self
+  }
+
+  public mutating func commit(completion: @escaping ((Error?) -> Void) = { _ in }) {
+    let future = swift_firebase.swift_cxx_shims.firebase.firestore.write_batch_commit(self)
+    future.setCompletion({
+      let (_, error) = future.resultAndError
+      DispatchQueue.main.async {
+        completion(error)
+      }
+    })
+  }
+
+  public mutating func commit() async throws {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+      let future = swift_firebase.swift_cxx_shims.firebase.firestore.write_batch_commit(self)
+      future.setCompletion({
+        let (_, error) = future.resultAndError
+        if let error {
+          continuation.resume(throwing: error)
+        } else {
+          continuation.resume()
+        }
+      })
+    }
+  }
+}

--- a/Sources/firebase/include/FirebaseCore.hh
+++ b/Sources/firebase/include/FirebaseCore.hh
@@ -21,6 +21,11 @@ class __attribute__((swift_attr("conforms_to:FirebaseCore.FutureProtocol")))
 
   Future(const ::firebase::Future<R>& rhs) : ::firebase::Future<R>(rhs) {}
 
+  // Allow explicit conversion from `Future<void>` in support of `VoidFuture`.
+  static Future From(const ::firebase::Future<void>& other) {
+    return Future(*reinterpret_cast<const ::firebase::Future<R>*>(&other));
+  }
+  
   void OnCompletion(
       _Nonnull FutureCompletionType completion,
       _Nullable void* user_data) const {

--- a/Sources/firebase/include/FirebaseCore.hh
+++ b/Sources/firebase/include/FirebaseCore.hh
@@ -31,6 +31,10 @@ class __attribute__((swift_attr("conforms_to:FirebaseCore.FutureProtocol")))
   }
 };
 
+// As a workaround, use `int` here instead of `void` for futures with no
+// result. Swift is not able to handle a `ResultType` of `void`.
+typedef Future<int> VoidFuture;
+
 } // namespace swift_firebase::swift_cxx_shims::firebase
 
 #endif

--- a/Sources/firebase/include/FirebaseCore.hh
+++ b/Sources/firebase/include/FirebaseCore.hh
@@ -23,6 +23,7 @@ class __attribute__((swift_attr("conforms_to:FirebaseCore.FutureProtocol")))
 
   // Allow explicit conversion from `Future<void>` in support of `VoidFuture`.
   static Future From(const ::firebase::Future<void>& other) {
+    static_assert(sizeof(::firebase::Future<void>) == sizeof(::firebase::Future<R>));
     return Future(*reinterpret_cast<const ::firebase::Future<R>*>(&other));
   }
   

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -63,7 +63,7 @@ firestore_batch(::firebase::firestore::Firestore *firestore) {
 
 // MARK: - DocumentReference
 
-inline ::firebase::firestore::Firestore*
+inline ::firebase::firestore::Firestore *
 document_firestore(::firebase::firestore::DocumentReference document) {
   return document.firestore();
 }

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -17,24 +17,24 @@
 namespace swift_firebase::swift_cxx_shims::firebase::firestore {
 
 inline ::firebase::firestore::Settings
-firestore_settings(::firebase::firestore::Firestore* firestore) {
+firestore_settings(::firebase::firestore::Firestore *firestore) {
   return firestore->settings();
 }
 
 inline ::firebase::firestore::DocumentReference
-firestore_document(::firebase::firestore::Firestore* firestore,
+firestore_document(::firebase::firestore::Firestore *firestore,
                    const ::std::string &document_path) {
   return firestore->Document(document_path);
 }
 
 inline ::firebase::firestore::CollectionReference
-firestore_collection(::firebase::firestore::Firestore* firestore,
+firestore_collection(::firebase::firestore::Firestore *firestore,
                      const ::std::string &collection_path) {
   return firestore->Collection(collection_path);
 }
 
 typedef ::firebase::firestore::Error (*FirebaseRunTransactionUpdateCallback)(
-    TransactionWeakReference* transaction,
+    TransactionWeakReference *transaction,
     std::string& error_message,
     void *user_data);
 inline VoidFuture
@@ -42,7 +42,7 @@ firestore_run_transaction(
     ::firebase::firestore::Firestore* firestore,
     ::firebase::firestore::TransactionOptions options,
     FirebaseRunTransactionUpdateCallback update_callback,
-    void* user_data) {
+    void *user_data) {
   return VoidFuture::From(
       firestore->RunTransaction(options, [update_callback, user_data](
           ::firebase::firestore::Transaction& transaction,

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -37,13 +37,13 @@ typedef ::firebase::firestore::Error (*FirebaseRunTransactionUpdateCallback)(
     TransactionWeakReference* transaction,
     std::string& error_message,
     void *user_data);
-inline ::swift_firebase::swift_cxx_shims::firebase::VoidFuture
+inline VoidFuture
 firestore_run_transaction(
     ::firebase::firestore::Firestore* firestore,
     ::firebase::firestore::TransactionOptions options,
     FirebaseRunTransactionUpdateCallback update_callback,
     void* user_data) {
-  return ::swift_firebase::swift_cxx_shims::firebase::VoidFuture::From(
+  return VoidFuture::From(
       firestore->RunTransaction(options, [update_callback, user_data](
           ::firebase::firestore::Transaction& transaction,
           std::string& error_message
@@ -54,6 +54,11 @@ firestore_run_transaction(
         transaction_ref.reset();
         return error;
       }));
+}
+
+inline ::firebase::firestore::WriteBatch
+firestore_batch(::firebase::firestore::Firestore* firestore) {
+  return firestore->batch();
 }
 
 // MARK: - DocumentReference
@@ -307,7 +312,45 @@ query_snapshot_size(const ::firebase::firestore::QuerySnapshot& snapshot) {
   return snapshot.size();
 }
 
-// MARK: Transaction
+// MARK: WriteBatch
+
+inline ::firebase::firestore::WriteBatch&
+write_batch_set(
+    ::firebase::firestore::WriteBatch write_batch,
+    const ::firebase::firestore::DocumentReference& document,
+    const ::firebase::firestore::MapFieldValue& data,
+    const ::firebase::firestore::SetOptions& options =
+        ::firebase::firestore::SetOptions()) {
+  return write_batch.Set(document, data, options);
+}
+
+inline ::firebase::firestore::WriteBatch&
+write_batch_update(
+    ::firebase::firestore::WriteBatch write_batch,
+    const ::firebase::firestore::DocumentReference& document,
+    const ::firebase::firestore::MapFieldValue& data) {
+  return write_batch.Update(document, data);
+}
+
+inline ::firebase::firestore::WriteBatch&
+write_batch_update(
+    ::firebase::firestore::WriteBatch write_batch,
+    const ::firebase::firestore::DocumentReference& document,
+    const ::firebase::firestore::MapFieldPathValue& data) {
+  return write_batch.Update(document, data);
+}
+
+inline ::firebase::firestore::WriteBatch&
+write_batch_delete(
+    ::firebase::firestore::WriteBatch write_batch,
+    const ::firebase::firestore::DocumentReference& document) {
+  return write_batch.Delete(document);
+}
+
+inline VoidFuture
+write_batch_commit(::firebase::firestore::WriteBatch write_batch) {
+  return VoidFuture::From(write_batch.Commit());
+}
 
 } // namespace swift_firebase::swift_cxx_shims::firebase::firestore
 

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -39,7 +39,7 @@ typedef ::firebase::firestore::Error (*FirebaseRunTransactionUpdateCallback)(
     void *user_data);
 inline VoidFuture
 firestore_run_transaction(
-    ::firebase::firestore::Firestore* firestore,
+    ::firebase::firestore::Firestore *firestore,
     ::firebase::firestore::TransactionOptions options,
     FirebaseRunTransactionUpdateCallback update_callback,
     void *user_data) {
@@ -57,7 +57,7 @@ firestore_run_transaction(
 }
 
 inline ::firebase::firestore::WriteBatch
-firestore_batch(::firebase::firestore::Firestore* firestore) {
+firestore_batch(::firebase::firestore::Firestore *firestore) {
   return firestore->batch();
 }
 

--- a/Sources/firebase/include/TransactionWeakReference.hh
+++ b/Sources/firebase/include/TransactionWeakReference.hh
@@ -25,6 +25,38 @@ class TransactionWeakReference {
     container_->transaction = transaction;
   }
 
+  bool is_valid() const { return container_->transaction != nullptr; }
+
+  // API wrappers to access the underlying Transaction:
+
+  void Set(const ::firebase::firestore::DocumentReference& document,
+           const ::firebase::firestore::MapFieldValue& data,
+           const ::firebase::firestore::SetOptions& options =
+              ::firebase::firestore::SetOptions()) {
+    container_->transaction->Set(document, data, options);
+  }
+
+  void Update(const ::firebase::firestore::DocumentReference& document,
+              const ::firebase::firestore::MapFieldValue& data) {
+    container_->transaction->Update(document, data);
+  }
+
+  void Update(const ::firebase::firestore::DocumentReference& document,
+              const ::firebase::firestore::MapFieldPathValue& data) {
+    container_->transaction->Update(document, data);
+  }
+
+  void Delete(const ::firebase::firestore::DocumentReference& document) {
+    container_->transaction->Delete(document);
+  }
+
+  ::firebase::firestore::DocumentSnapshot Get(
+      const ::firebase::firestore::DocumentReference& document,
+      ::firebase::firestore::Error* error_code,
+      std::string* error_message) {
+    return container_->transaction->Get(document, error_code, error_message);
+  }
+
  private:
   struct Container {
     Container(::firebase::firestore::Transaction* transaction)

--- a/Sources/firebase/include/TransactionWeakReference.hh
+++ b/Sources/firebase/include/TransactionWeakReference.hh
@@ -21,8 +21,8 @@ class TransactionWeakReference {
 
   TransactionWeakReference(::firebase::firestore::Transaction* transaction = nullptr)
       : container_(std::make_shared<Container>(transaction)) {}
-  void reset() {
-    container_->transaction = nullptr;
+  void reset(::firebase::firestore::Transaction* transaction = nullptr) {
+    container_->transaction = transaction;
   }
 
  private:

--- a/Sources/firebase/include/TransactionWeakReference.hh
+++ b/Sources/firebase/include/TransactionWeakReference.hh
@@ -1,0 +1,39 @@
+#ifndef firebase_include_TransactionWeakReference_hh
+#define firebase_include_TransactionWeakReference_hh
+
+#include <memory>
+
+namespace swift_firebase::swift_cxx_shims::firebase::firestore {
+
+// Transaction is non-copyable so we need a wrapper type that is copyable.
+// This type will hold a valid Transaction during the scope of a RunTransaction
+// callback (see Firestore+Swift.swift for details).
+class TransactionWeakReference {
+ public:
+  ~TransactionWeakReference() = default;
+
+  TransactionWeakReference(const TransactionWeakReference& other)
+      : container_(other.container_) {}
+  TransactionWeakReference& operator=(const TransactionWeakReference& other) {
+    container_ = other.container_;
+    return *this;
+  }
+
+  TransactionWeakReference(::firebase::firestore::Transaction* transaction = nullptr)
+      : container_(std::make_shared<Container>(transaction)) {}
+  void reset() {
+    container_->transaction = nullptr;
+  }
+
+ private:
+  struct Container {
+    Container(::firebase::firestore::Transaction* transaction)
+        : transaction(transaction) {}
+    ::firebase::firestore::Transaction* transaction;
+  };
+  std::shared_ptr<Container> container_;
+};
+
+} // namespace swift_firebase::swift_cxx_shims::firebase::firestore
+
+#endif


### PR DESCRIPTION
Adds:
- `Transaction`, `TransactionOptions` and `WriteBatch` types
- `VoidFuture` as workaround for `Future<void>`
- `TransactionWeakReference` as a wrapper for `Transaction` since `Transaction` cannot be exposed directly to Swift given that it is a non-copyable type.