### PR TITLE
API correctness fixes for DocumentChange support

### DIFF
--- a/Sources/FirebaseFirestore/DocumentChange+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentChange+Swift.swift
@@ -13,7 +13,7 @@ extension DocumentChange {
     swift_firebase.swift_cxx_shims.firebase.firestore.document_change_type(self)
   }
 
-  public var document: DocumentSnapshot {
+  public var document: QueryDocumentSnapshot {
     swift_firebase.swift_cxx_shims.firebase.firestore.document_change_document(self)
   }
 

--- a/Sources/FirebaseFirestore/DocumentChange+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentChange+Swift.swift
@@ -14,7 +14,7 @@ extension DocumentChange {
   }
 
   public var document: QueryDocumentSnapshot {
-    swift_firebase.swift_cxx_shims.firebase.firestore.document_change_document(self)
+    .init(snapshot: swift_firebase.swift_cxx_shims.firebase.firestore.document_change_document(self))
   }
 
   public var oldIndex: UInt {

--- a/Sources/FirebaseFirestore/DocumentChange+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentChange+Swift.swift
@@ -6,11 +6,16 @@ import firebase
 import CxxShim
 
 public typealias DocumentChange = firebase.firestore.DocumentChange
-public typealias DocumentChangeType = firebase.firestore.DocumentChange.`Type`
+
+public enum DocumentChangeType: Int {
+  case added
+  case modified
+  case removed
+}
 
 extension DocumentChange {
   public var type: DocumentChangeType {
-    swift_firebase.swift_cxx_shims.firebase.firestore.document_change_type(self)
+    .fromType(swift_firebase.swift_cxx_shims.firebase.firestore.document_change_type(self))
   }
 
   public var document: QueryDocumentSnapshot {
@@ -23,5 +28,11 @@ extension DocumentChange {
 
   public var newIndex: UInt {
     UInt(swift_firebase.swift_cxx_shims.firebase.firestore.document_change_new_index(self))
+  }
+}
+
+private extension DocumentChangeType {
+  static func fromType(_ type: firebase.firestore.DocumentChange.`Type`) -> DocumentChangeType {
+    .init(rawValue: Int(type.rawValue))!
   }
 }

--- a/Sources/FirebaseFirestore/DocumentSnapshot+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentSnapshot+Swift.swift
@@ -18,15 +18,20 @@ public typealias FieldValue = firebase.firestore.FieldValue
 
 extension DocumentSnapshot {
   public var reference: DocumentReference {
-    swift_firebase.swift_cxx_shims.firebase.firestore.snapshot_reference(self)
+    swift_firebase.swift_cxx_shims.firebase.firestore.document_snapshot_reference(self)
   }
 
   public var exists: Bool {
-    swift_firebase.swift_cxx_shims.firebase.firestore.snapshot_exists(self)
+    swift_firebase.swift_cxx_shims.firebase.firestore.document_snapshot_exists(self)
+  }
+
+  public var documentID: String {
+    String(swift_firebase.swift_cxx_shims.firebase.firestore.document_snapshot_id(self).pointee)
   }
 
   public func data(with behavior: ServerTimestampBehavior = .default) -> [String: Any]? {
-    let data = swift_firebase.swift_cxx_shims.firebase.firestore.snapshot_get_data_workaround(self, behavior)
+    guard exists else { return nil }
+    let data = swift_firebase.swift_cxx_shims.firebase.firestore.document_snapshot_get_data_workaround(self, behavior)
     return FirestoreDataConverter.value(workaround: data)
   }
 }

--- a/Sources/FirebaseFirestore/DocumentSnapshot+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentSnapshot+Swift.swift
@@ -25,7 +25,7 @@ extension DocumentSnapshot {
     swift_firebase.swift_cxx_shims.firebase.firestore.snapshot_exists(self)
   }
 
-  public func data(with behavior: ServerTimestampBehavior) -> [String: Any]? {
+  public func data(with behavior: ServerTimestampBehavior = .default) -> [String: Any]? {
     let data = swift_firebase.swift_cxx_shims.firebase.firestore.snapshot_get_data_workaround(self, behavior)
     return FirestoreDataConverter.value(workaround: data)
   }

--- a/Sources/FirebaseFirestore/FirestoreDataConverter.swift
+++ b/Sources/FirebaseFirestore/FirestoreDataConverter.swift
@@ -4,8 +4,8 @@ import Foundation
 import Cxx
 
 internal struct FirestoreDataConverter {
-  static func value(workaround: swift_firebase.swift_cxx_shims.firebase.firestore.MapFieldValue_Workaround) -> [String: Any]? {
-    guard workaround.keys.size() == workaround.values.size() else { return nil }
+  static func value(workaround: swift_firebase.swift_cxx_shims.firebase.firestore.MapFieldValue_Workaround) -> [String: Any] {
+    guard workaround.keys.size() == workaround.values.size() else { fatalError("Internal error: keys and values should be the same size.") }
 
     return Dictionary(uniqueKeysWithValues: zip(workaround.keys, workaround.values).lazy.compactMap {
       guard let converted = FirestoreDataConverter.value(field: $0.1) else { return nil }

--- a/Sources/FirebaseFirestore/QueryDocumentSnapshot.swift
+++ b/Sources/FirebaseFirestore/QueryDocumentSnapshot.swift
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+public struct QueryDocumentSnapshot {
+  private let snapshot: DocumentSnapshot
+
+  internal init(snapshot: DocumentSnapshot) {
+    self.snapshot = snapshot
+  }
+
+  func data() -> [String : Any] {
+    snapshot.data()!
+  }
+
+  func data(with serverTimestampBehavior: ServerTimestampBehavior) -> [String : Any] {
+    snapshot.data(with: serverTimestampBehavior)!
+  }
+}

--- a/Sources/FirebaseFirestore/QueryDocumentSnapshot.swift
+++ b/Sources/FirebaseFirestore/QueryDocumentSnapshot.swift
@@ -21,7 +21,7 @@ public struct QueryDocumentSnapshot {
     snapshot.documentID
   }
 
-  func data(with serverTimestampBehavior: ServerTimestampBehavior = .default) -> [String : Any] {
+  public func data(with serverTimestampBehavior: ServerTimestampBehavior = .default) -> [String : Any] {
     snapshot.data(with: serverTimestampBehavior)! // This should never fail
   }
 }

--- a/Sources/FirebaseFirestore/QueryDocumentSnapshot.swift
+++ b/Sources/FirebaseFirestore/QueryDocumentSnapshot.swift
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
+// Wraps a DocumentSnapshot providing a `data(with:)` implementation that
+// cannot return `nil`.
 public struct QueryDocumentSnapshot {
   private let snapshot: DocumentSnapshot
 
@@ -7,11 +9,19 @@ public struct QueryDocumentSnapshot {
     self.snapshot = snapshot
   }
 
-  func data() -> [String : Any] {
-    snapshot.data()!
+  public var reference: DocumentReference {
+    snapshot.reference
   }
 
-  func data(with serverTimestampBehavior: ServerTimestampBehavior) -> [String : Any] {
-    snapshot.data(with: serverTimestampBehavior)!
+  public var exists: Bool {
+    snapshot.exists
+  }
+
+  public var documentID: String {
+    snapshot.documentID
+  }
+
+  func data(with serverTimestampBehavior: ServerTimestampBehavior = .default) -> [String : Any] {
+    snapshot.data(with: serverTimestampBehavior)! // This should never fail
   }
 }

--- a/Sources/FirebaseFirestore/QueryDocumentSnapshot.swift
+++ b/Sources/FirebaseFirestore/QueryDocumentSnapshot.swift
@@ -21,7 +21,7 @@ public struct QueryDocumentSnapshot {
     snapshot.documentID
   }
 
-  public func data(with serverTimestampBehavior: ServerTimestampBehavior = .default) -> [String : Any] {
+  public func data(with behavior: ServerTimestampBehavior = .default) -> [String : Any] {
     let data = swift_firebase.swift_cxx_shims.firebase.firestore.document_snapshot_get_data_workaround(snapshot, behavior)
     return FirestoreDataConverter.value(workaround: data)
   }

--- a/Sources/FirebaseFirestore/QueryDocumentSnapshot.swift
+++ b/Sources/FirebaseFirestore/QueryDocumentSnapshot.swift
@@ -22,6 +22,7 @@ public struct QueryDocumentSnapshot {
   }
 
   public func data(with serverTimestampBehavior: ServerTimestampBehavior = .default) -> [String : Any] {
-    snapshot.data(with: serverTimestampBehavior)! // This should never fail
+    let data = swift_firebase.swift_cxx_shims.firebase.firestore.document_snapshot_get_data_workaround(snapshot, behavior)
+    return FirestoreDataConverter.value(workaround: data)
   }
 }

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -102,12 +102,12 @@ document_collection(::firebase::firestore::DocumentReference document,
 // MARK: - DocumentSnapshot
 
 inline ::firebase::firestore::DocumentReference
-snapshot_reference(const ::firebase::firestore::DocumentSnapshot snapshot) {
+document_snapshot_reference(const ::firebase::firestore::DocumentSnapshot snapshot) {
   return snapshot.reference();
 }
 
 inline bool
-snapshot_exists(const ::firebase::firestore::DocumentSnapshot &snapshot) {
+document_snapshot_exists(const ::firebase::firestore::DocumentSnapshot &snapshot) {
   return snapshot.exists();
 }
 
@@ -131,7 +131,7 @@ inline MapFieldValue_Workaround map_field_value_to_workaround(
   return std::move(data);
 }
 
-inline MapFieldValue_Workaround snapshot_get_data_workaround(
+inline MapFieldValue_Workaround document_snapshot_get_data_workaround(
     const ::firebase::firestore::DocumentSnapshot snapshot,
     const ::firebase::firestore::DocumentSnapshot::ServerTimestampBehavior
         stb) {
@@ -145,6 +145,11 @@ field_value_workaround(::firebase::firestore::MapFieldValue value) {
   return map_field_value_to_workaround(value);
 }
 #endif
+
+inline const ::std::string&
+document_snapshot_id(::firebase::firestore::DocumentSnapshot snapshot) {
+  return snapshot.id();
+}
 
 inline ::firebase::firestore::DocumentReference
 collection_document(::firebase::firestore::CollectionReference collection,


### PR DESCRIPTION
Changes:
- Provides closed definition of `DocumentChangeType` to prevent warnings about possible unhandled types when using this enum from Swift. This aligns with the ObjC API.
- Fixes `DocumentChange.document` to return a `QueryDocumentSnapshot` instead of a `DocumentSnapshot`. The difference is that a `QueryDocumentSnapshot`'s `data(with:)` method cannot return `nil`.
- Minor tweak to the naming of the C++ shims for `DocumentSnapshot` to be prefixed with `document_snapshot_` instead of just `snapshot_` to help differentiate from other shims with "snapshot" in their names.
- Changes `FirestoreDataConverter.value(workaround:)` to not return `nil` but to instead `fatalError` if somehow the `keys` and `values` arrays are different sizes. This could only be due to an internal coding error and not due to bad input.
- Adds `QueryDocumentSnapshot` as a wrapper around a `DocumentSnapshot` since the C++ API does not know about `QueryDocumentSnapshot`. This type is added for consistency with the ObjC API.
- Adds support for `{Query}DocumentSnapshot.documentID` getter.