### PR TITLE
API correctness fixes for Transaction support

### DIFF
--- a/Sources/FirebaseFirestore/Transaction+Swift.swift
+++ b/Sources/FirebaseFirestore/Transaction+Swift.swift
@@ -9,28 +9,28 @@ import Foundation
 public typealias Transaction = swift_firebase.swift_cxx_shims.firebase.firestore.TransactionWeakReference
 
 extension Transaction {
-  public func setData(_ data: [String : Any], forDocument document: DocumentReference) -> Transaction {
+  public @discardableResult func setData(_ data: [String : Any], forDocument document: DocumentReference) -> Transaction {
     setData(data, forDocument: document, merge: false)
   }
 
-  public func setData(_ data: [String : Any], forDocument document: DocumentReference, merge: Bool) -> Transaction {
+  public @discardableResult func setData(_ data: [String : Any], forDocument document: DocumentReference, merge: Bool) -> Transaction {
     guard is_valid() else { fatalError("Transaction accessed outside of updateBlock") }
     self.Set(document, FirestoreDataConverter.firestoreValue(document: data), merge ? .Merge() : .init())
     return self
   }
 
   /* TODO: implement
-  public func setData(_ data: [String : Any], forDocument document: DocumentReference, mergeFields: [Any]) -> Transaction {
+  public @discardableResult func setData(_ data: [String : Any], forDocument document: DocumentReference, mergeFields: [Any]) -> Transaction {
   }
   */
 
-  public func updateData(_ fields: [String : Any], forDocument document: DocumentReference) -> Transaction {
+  public @discardableResult func updateData(_ fields: [String : Any], forDocument document: DocumentReference) -> Transaction {
     guard is_valid() else { fatalError("Transaction accessed outside of updateBlock") }
     self.Update(document, FirestoreDataConverter.firestoreValue(document: fields))
     return self
   }
 
-  public func deleteDocument(_ document: DocumentReference) -> Transaction {
+  public @discardableResult func deleteDocument(_ document: DocumentReference) -> Transaction {
     guard is_valid() else { fatalError("Transaction accessed outside of updateBlock") }
     Delete(document)
     return self

--- a/Sources/FirebaseFirestore/Transaction+Swift.swift
+++ b/Sources/FirebaseFirestore/Transaction+Swift.swift
@@ -9,35 +9,35 @@ import Foundation
 public typealias Transaction = swift_firebase.swift_cxx_shims.firebase.firestore.TransactionWeakReference
 
 extension Transaction {
-  public mutating func setData(_ data: [String : Any], forDocument document: DocumentReference) -> Transaction {
+  public func setData(_ data: [String : Any], forDocument document: DocumentReference) -> Transaction {
     setData(data, forDocument: document, merge: false)
   }
 
-  public mutating func setData(_ data: [String : Any], forDocument document: DocumentReference, merge: Bool) -> Transaction {
-    assert(is_valid())
+  public func setData(_ data: [String : Any], forDocument document: DocumentReference, merge: Bool) -> Transaction {
+    guard is_valid() else { fatalError("Transaction accessed outside of updateBlock") }
     self.Set(document, FirestoreDataConverter.firestoreValue(document: data), merge ? .Merge() : .init())
     return self
   }
 
   /* TODO: implement
-  public mutating func setData(_ data: [String : Any], forDocument document: DocumentReference, mergeFields: [Any]) -> Transaction {
+  public func setData(_ data: [String : Any], forDocument document: DocumentReference, mergeFields: [Any]) -> Transaction {
   }
   */
 
-  public mutating func updateData(_ fields: [String : Any], forDocument document: DocumentReference) -> Transaction {
-    assert(is_valid())
+  public func updateData(_ fields: [String : Any], forDocument document: DocumentReference) -> Transaction {
+    guard is_valid() else { fatalError("Transaction accessed outside of updateBlock") }
     self.Update(document, FirestoreDataConverter.firestoreValue(document: fields))
     return self
   }
 
-  public mutating func deleteDocument(_ document: DocumentReference) -> Transaction {
-    assert(is_valid())
+  public func deleteDocument(_ document: DocumentReference) -> Transaction {
+    guard is_valid() else { fatalError("Transaction accessed outside of updateBlock") }
     Delete(document)
     return self
   }
 
-  public mutating func getDocument(_ document: DocumentReference) throws -> DocumentSnapshot {
-    assert(is_valid())
+  public func getDocument(_ document: DocumentReference) throws -> DocumentSnapshot {
+    guard is_valid() else { fatalError("Transaction accessed outside of updateBlock") }
 
     var error = firebase.firestore.kErrorNone
     var errorMessage = std.string()

--- a/Sources/FirebaseFirestore/Transaction+Swift.swift
+++ b/Sources/FirebaseFirestore/Transaction+Swift.swift
@@ -9,28 +9,28 @@ import Foundation
 public typealias Transaction = swift_firebase.swift_cxx_shims.firebase.firestore.TransactionWeakReference
 
 extension Transaction {
-  public @discardableResult func setData(_ data: [String : Any], forDocument document: DocumentReference) -> Transaction {
+  @discardableResult public func setData(_ data: [String : Any], forDocument document: DocumentReference) -> Transaction {
     setData(data, forDocument: document, merge: false)
   }
 
-  public @discardableResult func setData(_ data: [String : Any], forDocument document: DocumentReference, merge: Bool) -> Transaction {
+  @discardableResult public func setData(_ data: [String : Any], forDocument document: DocumentReference, merge: Bool) -> Transaction {
     guard is_valid() else { fatalError("Transaction accessed outside of updateBlock") }
     self.Set(document, FirestoreDataConverter.firestoreValue(document: data), merge ? .Merge() : .init())
     return self
   }
 
   /* TODO: implement
-  public @discardableResult func setData(_ data: [String : Any], forDocument document: DocumentReference, mergeFields: [Any]) -> Transaction {
+  @discardableResult public func setData(_ data: [String : Any], forDocument document: DocumentReference, mergeFields: [Any]) -> Transaction {
   }
   */
 
-  public @discardableResult func updateData(_ fields: [String : Any], forDocument document: DocumentReference) -> Transaction {
+  @discardableResult public func updateData(_ fields: [String : Any], forDocument document: DocumentReference) -> Transaction {
     guard is_valid() else { fatalError("Transaction accessed outside of updateBlock") }
     self.Update(document, FirestoreDataConverter.firestoreValue(document: fields))
     return self
   }
 
-  public @discardableResult func deleteDocument(_ document: DocumentReference) -> Transaction {
+  @discardableResult public func deleteDocument(_ document: DocumentReference) -> Transaction {
     guard is_valid() else { fatalError("Transaction accessed outside of updateBlock") }
     Delete(document)
     return self

--- a/Sources/firebase/include/TransactionWeakReference.hh
+++ b/Sources/firebase/include/TransactionWeakReference.hh
@@ -32,28 +32,28 @@ class TransactionWeakReference {
   void Set(const ::firebase::firestore::DocumentReference& document,
            const ::firebase::firestore::MapFieldValue& data,
            const ::firebase::firestore::SetOptions& options =
-              ::firebase::firestore::SetOptions()) {
+              ::firebase::firestore::SetOptions()) const {
     container_->transaction->Set(document, data, options);
   }
 
   void Update(const ::firebase::firestore::DocumentReference& document,
-              const ::firebase::firestore::MapFieldValue& data) {
+              const ::firebase::firestore::MapFieldValue& data) const {
     container_->transaction->Update(document, data);
   }
 
   void Update(const ::firebase::firestore::DocumentReference& document,
-              const ::firebase::firestore::MapFieldPathValue& data) {
+              const ::firebase::firestore::MapFieldPathValue& data) const {
     container_->transaction->Update(document, data);
   }
 
-  void Delete(const ::firebase::firestore::DocumentReference& document) {
+  void Delete(const ::firebase::firestore::DocumentReference& document) const {
     container_->transaction->Delete(document);
   }
 
   ::firebase::firestore::DocumentSnapshot Get(
       const ::firebase::firestore::DocumentReference& document,
       ::firebase::firestore::Error* error_code,
-      std::string* error_message) {
+      std::string* error_message) const {
     return container_->transaction->Get(document, error_code, error_message);
   }
 


### PR DESCRIPTION
Changes:
- Fix signature of `runTransaction`'s `updateBlock` parameter
- Add definition of `NSErrorPointer` since swift-corelibs-foundation does not provide it
- Make `Transaction` methods that return the `Transaction` to support chaining declare the result discardable so as to not generate warnings when the return value is ignored
- Switch to a `fatalError` (even in release builds) if trying to use a `Transaction` outside of an `updateBlock`
- Switch to non-mutating methods / const C++ methods so that a `Transaction` instance passed as a parameter to a function (`updateBlock`) can be used