### PR TITLE
Fix Int handling by ensuring it will always be converted to Int64

### DIFF
--- a/Sources/FirebaseFirestore/FirestoreDataConverter.swift
+++ b/Sources/FirebaseFirestore/FirestoreDataConverter.swift
@@ -20,7 +20,7 @@ internal struct FirestoreDataConverter {
     case .boolean:
       return field.boolean_value()
     case .integer:
-      return field.integer_value()
+      return Int64(field.integer_value())
     case .double:
       return field.double_value()
     case .timestamp:
@@ -70,8 +70,8 @@ internal struct FirestoreDataConverter {
       guard let bool = field as? Bool else { return nil }
       return firebase.firestore.FieldValue.Boolean(bool)
     case is Int:
-      guard let int = field as? Int64 else { return nil }
-      return firebase.firestore.FieldValue.Integer(int)
+      guard let int = field as? Int else { return nil }
+      return firebase.firestore.FieldValue.Integer(Int64(int))
     case is Double:
       guard let double = field as? Double else { return nil }
       return firebase.firestore.FieldValue.Double(double)


### PR DESCRIPTION
On windows `Int` is not always `Int64`. This ensures that even if `Int32` is passed, it will always be interpreted as `Int64` to keep it compatible with darwin platforms where it's always `Int64`. Unfortunately this means that some of our code might use `Int` type incorrectly (it it exceeds `Int32` range), but for now this at least ensures it will work properly up to that limit.