### PR TITLE
Actually return FieldValue for serverTimestamp()

### DIFF
--- a/Sources/FirebaseFirestore/FieldValue+Swift.swift
+++ b/Sources/FirebaseFirestore/FieldValue+Swift.swift
@@ -6,7 +6,7 @@ import firebase
 public typealias FieldValue = firebase.firestore.FieldValue
 
 extension FieldValue {
-  public static func serverTimestamp() {
+  public static func serverTimestamp() -> Self {
     ServerTimestamp()
   }
 }


### PR DESCRIPTION
Seems like the return value is missing which caused those fields not to be populated.