### PR TITLE
Pass through FieldValue instead of converting it to nil when preparing for upload

### DIFF
--- a/Sources/FirebaseFirestore/FirestoreDataConverter.swift
+++ b/Sources/FirebaseFirestore/FirestoreDataConverter.swift
@@ -108,6 +108,8 @@ internal struct FirestoreDataConverter {
       }
 
       return firebase.firestore.FieldValue.Map(map)
+    case is firebase.firestore.FieldValue:
+      return field as! firebase.firestore.FieldValue
     default:
       return nil
     }


### PR DESCRIPTION
When we are converting values from `Any` to `FieldValue` we didn't actually handle the case in which user themselves passes `FieldValue`. This fixes that scenario by adding a passthrough case, that just converts `Any?` to `FieldValue` when appropriate. This fixes uploading `FieldValue.serverTimetamp()`.