### PR TITLE
Add support for calling the two-arg variant of runTransaction

### DIFF
--- a/Sources/FirebaseFirestore/Firestore+Swift.swift
+++ b/Sources/FirebaseFirestore/Firestore+Swift.swift
@@ -39,6 +39,10 @@ extension Firestore {
     swift_firebase.swift_cxx_shims.firebase.firestore.firestore_collection(self, std.string(collectionPath))
   }
 
+  public func runTransaction(_ updateBlock: @escaping (Transaction, NSErrorPointer) -> Any, completion: @escaping (Any?, Error?) -> Void) {
+    runTransaction(with: nil, block: updateBlock, completion: completion)
+  }
+
   public func runTransaction(_ updateBlock: @escaping (Transaction, NSErrorPointer) -> Any?, completion: @escaping (Any?, Error?) -> Void) {
     runTransaction(with: nil, block: updateBlock, completion: completion)
   }


### PR DESCRIPTION
When given a first argument closure that returns a non-optional type, the compiler would give up trying to match against the two-arg variant and instead complain about the first argument missing a `with:` label and not being a `TransactionOption` type.

A fix for this is to provide optional and non-optional variants of the two arg override.