### PR TITLE
Revise the way FirestoreErrorCode can be initialized

### DIFF
--- a/Sources/FirebaseFirestore/FirestoreErrorCode.swift
+++ b/Sources/FirebaseFirestore/FirestoreErrorCode.swift
@@ -20,8 +20,8 @@ public struct FirestoreErrorCode: Error {
     self.init(actualError, errorMessage: errorMessageString)
   }
 
-  public init(_ error: FirestoreErrorCode) {
-    self.init(error.code, errorMessage: error.localizedDescription)
+  public init(_ code: FirestoreErrorCode.Code) {
+    self.init(code, errorMessage: nil)
   }
 }
 

--- a/Sources/FirebaseFirestore/FirestoreErrorCode.swift
+++ b/Sources/FirebaseFirestore/FirestoreErrorCode.swift
@@ -6,7 +6,7 @@ public struct FirestoreErrorCode: Error {
   public let code: Code
   public let localizedDescription: String
 
-  public init(_ error: firebase.firestore.Error, errorMessage: String? = nil) {
+  init(_ error: firebase.firestore.Error, errorMessage: String?) {
     code = error
     localizedDescription = errorMessage ?? "\(code.rawValue)"
   }
@@ -18,6 +18,10 @@ public struct FirestoreErrorCode: Error {
       errorMessageString = .init(cString: errorMessage)
     }
     self.init(actualError, errorMessage: errorMessageString)
+  }
+
+  public init(_ code: Code) {
+    self.init(code, errorMessage: nil)
   }
 }
 

--- a/Sources/FirebaseFirestore/FirestoreErrorCode.swift
+++ b/Sources/FirebaseFirestore/FirestoreErrorCode.swift
@@ -6,18 +6,22 @@ public struct FirestoreErrorCode: Error {
   public let code: Code
   public let localizedDescription: String
 
-  public init(_ error: firebase.firestore.Error, errorMessage: String?) {
+  init(_ error: firebase.firestore.Error, errorMessage: String?) {
     code = error
     localizedDescription = errorMessage ?? "\(code.rawValue)"
   }
 
-  public init?(_ error: firebase.firestore.Error?, errorMessage: UnsafePointer<CChar>? = nil) {
+  init?(_ error: firebase.firestore.Error?, errorMessage: UnsafePointer<CChar>?) {
     guard let actualError = error, actualError.rawValue != 0 else { return nil }
     var errorMessageString: String?
     if let errorMessage {
       errorMessageString = .init(cString: errorMessage)
     }
     self.init(actualError, errorMessage: errorMessageString)
+  }
+
+  public init(_ error: FirestoreErrorCode) {
+    self.init(error.code, errorMessage: error.localizedDescription)
   }
 }
 

--- a/Sources/FirebaseFirestore/FirestoreErrorCode.swift
+++ b/Sources/FirebaseFirestore/FirestoreErrorCode.swift
@@ -6,7 +6,7 @@ public struct FirestoreErrorCode: Error {
   public let code: Code
   public let localizedDescription: String
 
-  init(_ error: firebase.firestore.Error, errorMessage: String?) {
+  public init(_ error: firebase.firestore.Error, errorMessage: String? = nil) {
     code = error
     localizedDescription = errorMessage ?? "\(code.rawValue)"
   }
@@ -18,10 +18,6 @@ public struct FirestoreErrorCode: Error {
       errorMessageString = .init(cString: errorMessage)
     }
     self.init(actualError, errorMessage: errorMessageString)
-  }
-
-  public init(_ code: FirestoreErrorCode.Code) {
-    self.init(code, errorMessage: nil)
   }
 }
 


### PR DESCRIPTION
Allow consumers to write code like `FirestoreErrorCode(.permissionDenied)`, which is supported by the Objective C API.