### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,8 +11,16 @@ set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
 include(FetchContent)
 
+option(SWIFT_FIREBASE_BUILD_EXAMPLES "Build example UI" TRUE)
+
+# ${TOOLCHAIN_ROOT}/usr/include allows us to access swift C++ interop headers.
+cmake_path(GET CMAKE_Swift_COMPILER PARENT_PATH _SWIFT_INCLUDE_DIR)
+cmake_path(GET _SWIFT_INCLUDE_DIR PARENT_PATH _SWIFT_INCLUDE_DIR)
+include_directories(SYSTEM ${_SWIFT_INCLUDE_DIR}/include)
+
 add_library(firebase INTERFACE)
 target_compile_options(firebase INTERFACE
+  "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -DSR69711>"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -DINTERNAL_EXPERIMENTAL>")
 target_include_directories(firebase INTERFACE
   Sources/firebase/include
@@ -22,46 +30,74 @@ target_link_directories(firebase INTERFACE
   third_party/firebase-development/usr/libs/windows/deps/app
   third_party/firebase-development/usr/libs/windows/deps/app/external)
 
-add_library(FirebaseCore
+add_library(FirebaseCore SHARED
   Sources/FirebaseCore/FirebaseApp+Swift.swift
   Sources/FirebaseCore/FirebaseConfiguration.swift
   Sources/FirebaseCore/FirebaseError.swift
   Sources/FirebaseCore/FirebaseLogging+Swift.swift
-  Sources/FirebaseCore/FirebaseOptions+Swift.swift)
+  Sources/FirebaseCore/FirebaseOptions+Swift.swift
+  Sources/FirebaseCore/FutureProtocol.swift)
 target_compile_options(FirebaseCore PRIVATE
   -cxx-interoperability-mode=default)
+target_link_libraries(FirebaseCore PUBLIC
+  firebase)
 target_link_libraries(FirebaseCore PRIVATE
   libcurl
-  firebase
+  firebase_app
+  flatbuffers
   zlibstatic)
 
-add_library(FirebaseAuth
+add_library(FirebaseAuth SHARED
+  Sources/FirebaseAuth/AuthStateDidChangeListenerHandle.swift
   Sources/FirebaseAuth/FIRActionCodeOperation.swift
   Sources/FirebaseAuth/FIRAuthTokenResult.swift
   Sources/FirebaseAuth/FirebaseAuth+Swift.swift
   Sources/FirebaseAuth/FirebaseAuthError.swift
   Sources/FirebaseAuth/FirebaseAuthResult+Swift.swift
+  Sources/FirebaseAuth/FirebaseEmailAuthProvider.swift
   Sources/FirebaseAuth/FirebaseUser+Swift.swift)
 target_compile_options(FirebaseAuth PRIVATE
   -cxx-interoperability-mode=default)
 target_link_libraries(FirebaseAuth PUBLIC
+  firebase
   FirebaseCore)
 target_link_libraries(FirebaseAuth PRIVATE
   crypto
-  firebase
   firebase_rest_lib
-  flatbuffers)
+  flatbuffers
+  libcurl
+  ssl
+  zlibstatic)
 
-add_library(FirebaseFirestore
+add_library(FirebaseFirestore SHARED
+  Sources/FirebaseFirestore/Vendor/Codable/CodableErrors.swift
+  Sources/FirebaseFirestore/Vendor/Codable/CodablePassThroughTypes.swift
+  Sources/FirebaseFirestore/Vendor/Codable/DocumentID.swift
+  Sources/FirebaseFirestore/Vendor/FirebaseDataEncoder/FirebaseDataEncoder.swift
+  Sources/FirebaseFirestore/Vendor/FirebaseDataEncoder/FirebaseRemoteConfigValueDecoding.swift
   Sources/FirebaseFirestore/CollectionReference+Swift.swift
+  Sources/FirebaseFirestore/DocumentChange+Swift.swift
   Sources/FirebaseFirestore/DocumentReference+Swift.swift
   Sources/FirebaseFirestore/DocumentSnapshot+Swift.swift
+  Sources/FirebaseFirestore/FieldValue+Swift.swift
   Sources/FirebaseFirestore/Firestore+Swift.swift
+  Sources/FirebaseFirestore/FirestoreDataConverter.swift
+  Sources/FirebaseFirestore/FirestoreErrorCode.swift
+  Sources/FirebaseFirestore/FirestoreSource+Swift.swift
   Sources/FirebaseFirestore/ListenerRegistration.swift
-  Sources/FirebaseFirestore/Settings+Swift.swift)
+  Sources/FirebaseFirestore/Query+Swift.swift
+  Sources/FirebaseFirestore/QueryDocumentSnapshot.swift
+  Sources/FirebaseFirestore/QuerySnapshot+Swift.swift
+  Sources/FirebaseFirestore/Settings+Swift.swift
+  Sources/FirebaseFirestore/SnapshotMetadata+Swift.swift
+  Sources/FirebaseFirestore/Timestamp+Swift.swift
+  Sources/FirebaseFirestore/Transaction+Swift.swift
+  Sources/FirebaseFirestore/TransactionOptions+Swift.swift
+  Sources/FirebaseFirestore/WriteBatch+Swift.swift)
 target_compile_options(FirebaseFirestore PRIVATE
   -cxx-interoperability-mode=default)
 target_link_libraries(FirebaseFirestore PUBLIC
+  firebase
   FirebaseCore)
 target_link_libraries(FirebaseFirestore PRIVATE
   absl_bad_optional_access
@@ -103,41 +139,47 @@ target_link_libraries(FirebaseFirestore PRIVATE
   absl_time_zone
   address_sorting
   cares
-  firebase
+  crypto
   firestore_core
   firestore_nanopb
   firestore_protos_nanopb
+  firebase_rest_lib
   firestore_util
+  flatbuffers
   gpr
   grpc
   grpc++
   leveldb
+  libcurl
   protobuf-nanopb
   re2
   snappy
   ssl
-  upb)
+  upb
+  zlibstatic)
 
-FetchContent_Declare(SwiftWin32
-  GIT_REPOSITORY https://github.com/compnerd/swift-win32
-  GIT_TAG 07e91e67e86f173743329c6753d9e66ac4727830) # Pinned for reproducibility and before Package@swift-#.#.swift symlinks 
-FetchContent_MakeAvailable(SwiftWin32)
+if(SWIFT_FIREBASE_BUILD_EXAMPLES)
+  FetchContent_Declare(SwiftWin32
+    GIT_REPOSITORY https://github.com/compnerd/swift-win32
+    GIT_TAG 07e91e67e86f173743329c6753d9e66ac4727830) # Pinned for reproducibility and before Package@swift-#.#.swift symlinks
+  FetchContent_MakeAvailable(SwiftWin32)
 
-add_executable(FireBaseUI
-  Examples/FireBaseUI/FireBaseUI.swift
-  Examples/FireBaseUI/FireBaseUIViewController.swift
-  Examples/FireBaseUI/FirestoreTestingViewController.swift
-  Examples/FireBaseUI/SceneDelegate.swift
-  Examples/FireBaseUI/SwiftWin32+Extensions.swift)
-target_compile_options(FireBaseUI PRIVATE
-  -parse-as-library
-  -cxx-interoperability-mode=default)
-target_link_libraries(FireBaseUI PRIVATE
-  FirebaseCore
-  FirebaseAuth
-  FirebaseFirestore
-  SwiftWin32)
-add_custom_command(TARGET FireBaseUI POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Examples/FireBaseUI/Resources $<TARGET_FILE_DIR:FireBaseUI>/Resources
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Examples/FireBaseUI/Info.plist $<TARGET_FILE_DIR:FireBaseUI>/Info.plist
-  COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Examples/FireBaseUI/$<TARGET_FILE_NAME:FireBaseUI>.manifest $<TARGET_FILE_DIR:FireBaseUI>/$<TARGET_FILE_NAME:FireBaseUI>.manifest)
+  add_executable(FireBaseUI
+    Examples/FireBaseUI/FireBaseUI.swift
+    Examples/FireBaseUI/FireBaseUIViewController.swift
+    Examples/FireBaseUI/FirestoreTestingViewController.swift
+    Examples/FireBaseUI/SceneDelegate.swift
+    Examples/FireBaseUI/SwiftWin32+Extensions.swift)
+  target_compile_options(FireBaseUI PRIVATE
+    -parse-as-library
+    -cxx-interoperability-mode=default)
+  target_link_libraries(FireBaseUI PRIVATE
+    FirebaseCore
+    FirebaseAuth
+    FirebaseFirestore
+    SwiftWin32)
+  add_custom_command(TARGET FireBaseUI POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Examples/FireBaseUI/Resources $<TARGET_FILE_DIR:FireBaseUI>/Resources
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Examples/FireBaseUI/Info.plist $<TARGET_FILE_DIR:FireBaseUI>/Info.plist
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/Examples/FireBaseUI/$<TARGET_FILE_NAME:FireBaseUI>.manifest $<TARGET_FILE_DIR:FireBaseUI>/$<TARGET_FILE_NAME:FireBaseUI>.manifest)
+endif()


### PR DESCRIPTION
Update the CMakeLists.txt to contain the latest changes. This also introduces a new option `SWIFT_FIREBASE_BUILD_EXAMPLES` to allow disabling the examples. This change is motivated by the desire to cross-compile this to other platforms (e.g. Android), which is not possible via SPM.