### PR TITLE
Allow transaction updateBlock to return Error instead of NSError

### DIFF
--- a/Sources/FirebaseFirestore/Firestore+Swift.swift
+++ b/Sources/FirebaseFirestore/Firestore+Swift.swift
@@ -12,7 +12,7 @@ public typealias Firestore = UnsafeMutablePointer<firebase.firestore.Firestore>
 
 // On Apple platforms, this is defined by Foundation using AutoreleasingUnsafeMutablePointer.
 // That type is specific to the ObjC runtime, so we don't have access to it. Use this instead.
-public typealias NSErrorPointer = UnsafeMutablePointer<NSError?>?
+public typealias NSErrorPointer = UnsafeMutablePointer<Error?>?
 
 extension Firestore {
   public static func firestore() -> Firestore {
@@ -91,7 +91,7 @@ extension Firestore {
 
     let updateBlock: UpdateBlock
     var result: Any?
-    var error: NSError?
+    var error: Error?
 
     init(updateBlock: @escaping UpdateBlock) {
       self.updateBlock = updateBlock


### PR DESCRIPTION
Unfortunately Error > NSError > Error is lossy on Windows.

```
enum MyErrorType: Error {
  case someError
}
```

Given code such as the above, if you convert an instance of `MyErrorType` to `NSError`, the result is no longer an instance of `MyErrorType`. This does not happen on Apple platforms.

This causes issues when trying to propagate an error generated from `runTransaction`'s `updateBlock` to the caller of `runTransaction`.

A solution is to just use `Error` instead of `NSError` in the API.