### PR TITLE
Add FieldValue Equatable conformance

### DIFF
--- a/Sources/FirebaseFirestore/FieldValue+Swift.swift
+++ b/Sources/FirebaseFirestore/FieldValue+Swift.swift
@@ -10,3 +10,5 @@ extension FieldValue {
     ServerTimestamp()
   }
 }
+
+extension FieldValue: Equatable {}


### PR DESCRIPTION
The compiler is able to implement the conformance itself given the existing C++ `operator==` for the underlying `FieldValue` type. We just need to declare that we want it.