### PR TITLE
Respect include_metadata_changes argument when creating listeners

### DIFF
--- a/Sources/FirebaseFirestore/DocumentReference+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentReference+Swift.swift
@@ -60,7 +60,9 @@ extension DocumentReference {
     typealias ListenerCallback = (DocumentSnapshot?, Error?) -> Void
     let boxed = Unmanaged.passRetained(listener as AnyObject)
     let instance = swift_firebase.swift_cxx_shims.firebase.firestore.document_add_snapshot_listener(
-      self, { snapshot, errorCode, errorMessage, pvListener in
+      includeMetadataChanges,
+      self,
+      { snapshot, errorCode, errorMessage, pvListener in
         let callback = Unmanaged<AnyObject>.fromOpaque(pvListener!).takeUnretainedValue() as! ListenerCallback
 
         let error = FirestoreErrorCode(errorCode, errorMessage: errorMessage)

--- a/Sources/FirebaseFirestore/Query+Swift.swift
+++ b/Sources/FirebaseFirestore/Query+Swift.swift
@@ -61,7 +61,9 @@ extension QueryProtocol {
     typealias ListenerCallback = (QuerySnapshot?, Error?) -> Void
     let boxed = Unmanaged.passRetained(listener as AnyObject)
     let instance = swift_firebase.swift_cxx_shims.firebase.firestore.query_add_snapshot_listener(
-      _asQuery, { snapshot, errorCode, errorMessage, pvListener in
+      includeMetadataChanges,
+      _asQuery,
+      { snapshot, errorCode, errorMessage, pvListener in
         let callback = Unmanaged<AnyObject>.fromOpaque(pvListener!).takeUnretainedValue() as! ListenerCallback
 
         let error = FirestoreErrorCode(errorCode, errorMessage: errorMessage)

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -176,9 +176,11 @@ typedef void (*DocumentSnapshotListenerTypedCallback)(
     void *user_data);
 inline ::firebase::firestore::ListenerRegistration
 document_add_snapshot_listener(
+    bool include_metadata_changes,
     ::firebase::firestore::DocumentReference document,
     DocumentSnapshotListenerTypedCallback callback, void *user_data) {
   return document.AddSnapshotListener(
+      include_metadata_changes ? ::firebase::firestore::MetadataChanges::kInclude : ::firebase::firestore::MetadataChanges::kExclude,
       [callback, user_data](
           const ::firebase::firestore::DocumentSnapshot &snapshot,
           ::firebase::firestore::Error error_code,
@@ -241,9 +243,11 @@ typedef void (*QuerySnapshotListenerTypedCallback)(
     void *user_data);
 inline ::firebase::firestore::ListenerRegistration
 query_add_snapshot_listener(
+    bool include_metadata_changes,
     ::firebase::firestore::Query query,
     QuerySnapshotListenerTypedCallback callback, void *user_data) {
   return query.AddSnapshotListener(
+      include_metadata_changes ? ::firebase::firestore::MetadataChanges::kInclude : ::firebase::firestore::MetadataChanges::kExclude,
       [callback, user_data](
           const ::firebase::firestore::QuerySnapshot &snapshot,
           ::firebase::firestore::Error error_code,


### PR DESCRIPTION
So far we were ignoring `includeMetadataChanges` flag, which is an important part of initialization process. This led to sync getting stuck until some change came from remote, and never upload if during startup local cache was matching the state of remote.

This seems to be underlying cause for [WPP-1699](https://linear.app/the-browser-company/issue/WPP-1699/restarting-sync-quickly-gets-it-stuck-in-the-getting-initial-data).

This just pipes it through to the underling C++ implementation casting bool to enum in between.

I didn't test document snapshot listener, but I did test query snapshot listener by confirming that with those changes the [WPP-1699](https://linear.app/the-browser-company/issue/WPP-1699/restarting-sync-quickly-gets-it-stuck-in-the-getting-initial-data) is fixed.