### PR TITLE
Expose firestore settings

### DIFF
--- a/Sources/FirebaseFirestore/DocumentReference+Swift.swift
+++ b/Sources/FirebaseFirestore/DocumentReference+Swift.swift
@@ -16,7 +16,7 @@ extension DocumentReference {
   }
 
   public var firestore: Firestore {
-    swift_firebase.swift_cxx_shims.firebase.firestore.document_firestore(self)!
+    .init(swift_firebase.swift_cxx_shims.firebase.firestore.document_firestore(self)!)
   }
 
   public func collection(_ path: String) -> CollectionReference {

--- a/Sources/FirebaseFirestore/Query+Swift.swift
+++ b/Sources/FirebaseFirestore/Query+Swift.swift
@@ -25,7 +25,7 @@ extension Query: QueryProtocol {
 
 extension QueryProtocol {
   public var firestore: Firestore {
-    swift_firebase.swift_cxx_shims.firebase.firestore.query_firestore(_asQuery)
+    .init(swift_firebase.swift_cxx_shims.firebase.firestore.query_firestore(_asQuery))
   }
 
   // This variant is provided for compatibility with the ObjC API.

--- a/Sources/FirebaseFirestore/Settings+Swift.swift
+++ b/Sources/FirebaseFirestore/Settings+Swift.swift
@@ -8,10 +8,29 @@ import FirebaseCore
 import CxxShim
 import Foundation
 
-public typealias Settings = firebase.firestore.Settings
+public struct FirestoreSettings {
+  var impl: firebase.firestore.Settings
 
-extension Settings: CustomDebugStringConvertible {
+  init(_ impl: firebase.firestore.Settings) {
+    self.impl = impl
+  }
+
+  public init() {
+    impl = .init()
+  }
+
   public var debugDescription: String {
-    String(ToString())
+    String(impl.ToString())
+  }
+
+  public var isPersistenceEnabled: Bool {
+    get {
+      impl.is_persistence_enabled()
+    }
+    set {
+      impl.set_persistence_enabled(newValue)
+    }
   }
 }
+
+extension FirestoreSettings: CustomDebugStringConvertible {}

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -21,6 +21,11 @@ firestore_settings(::firebase::firestore::Firestore *firestore) {
   return firestore->settings();
 }
 
+inline void
+firestore_set_settings(::firebase::firestore::Firestore *firestore, ::firebase::firestore::Settings settings) {
+  return firestore->set_settings(settings);
+}
+
 inline ::firebase::firestore::DocumentReference
 firestore_document(::firebase::firestore::Firestore *firestore,
                    const ::std::string &document_path) {


### PR DESCRIPTION
Switches to wrapping the C++ `Firestore` object with a Swift class so that the `Firestore` object takes on reference semantics. This allows for code like `Firestore.firestore().settings = ...`

Renames `Settings` to `FirestoreSettings`, also providing a wrapper. This time using value semantics. But the wrapper helps hide the C++ methods that are named differently than the Obj C API we are trying to emmulate.

Expose `isPersistenceEnabled` setting.