### PR TITLE
Expose Firestore.terminate

### DIFF
--- a/Sources/FirebaseFirestore/Firestore+Swift.swift
+++ b/Sources/FirebaseFirestore/Firestore+Swift.swift
@@ -44,11 +44,13 @@ public class Firestore {
     }
   }
 
-  public func clearPersistence(completion: @escaping () -> Void) {
+  public func clearPersistence(completion: (() -> Void)?) {
     let future = swift_firebase.swift_cxx_shims.firebase.firestore.firestore_clear_persistence(impl)
     future.setCompletion({
-      DispatchQueue.main.async {
-        completion()
+      if let completion {
+        DispatchQueue.main.async {
+          completion()
+        }
       }
     })
   }
@@ -56,6 +58,26 @@ public class Firestore {
   public func clearPersistence() async {
     await withCheckedContinuation { continuation in
       let future = swift_firebase.swift_cxx_shims.firebase.firestore.firestore_clear_persistence(impl)
+      future.setCompletion({
+        continuation.resume()
+      })
+    }
+  }
+
+  public func terminate(completion: (() -> Void)?) {
+    let future = swift_firebase.swift_cxx_shims.firebase.firestore.firestore_terminate(impl)
+    future.setCompletion({
+      if let completion {
+        DispatchQueue.main.async {
+          completion()
+        }
+      }
+    })
+  }
+
+  public func terminate() async {
+    await withCheckedContinuation { continuation in
+      let future = swift_firebase.swift_cxx_shims.firebase.firestore.firestore_terminate(impl)
       future.setCompletion({
         continuation.resume()
       })

--- a/Sources/firebase/include/FirebaseFirestore.hh
+++ b/Sources/firebase/include/FirebaseFirestore.hh
@@ -31,6 +31,11 @@ firestore_clear_persistence(::firebase::firestore::Firestore *firestore) {
   return VoidFuture::From(firestore->ClearPersistence());
 }
 
+inline VoidFuture
+firestore_terminate(::firebase::firestore::Firestore *firestore) {
+  return VoidFuture::From(firestore->Terminate());
+}
+
 inline ::firebase::firestore::DocumentReference
 firestore_document(::firebase::firestore::Firestore *firestore,
                    const ::std::string &document_path) {


### PR DESCRIPTION
Also fixes signature of `clearPersistence` to allow for a `nil` completion callback to match the Obj C API.