### PR TITLE
firebase: fully qualify a type name

### DIFF
--- a/Sources/firebase/include/FirebaseCore.hh
+++ b/Sources/firebase/include/FirebaseCore.hh
@@ -31,7 +31,7 @@ class SWIFT_CONFORMS_TO_PROTOCOL(FirebaseCore.FutureProtocol)
       _Nonnull FutureCompletionType completion,
       _Nullable void* user_data) const {
     ::firebase::FutureBase::OnCompletion(
-        [completion, user_data](const FutureBase&) {
+        [completion, user_data](const ::firebase::FutureBase&) {
           completion(user_data);
         });
   }


### PR DESCRIPTION
This corrects a failure to resolve the typename `FutureBase` when building for Android.