### PR TITLE
FirebaseAndroid: introduce `SwiftFirebase` JAR

### DIFF
--- a/Sources/FirebaseAndroid/CMakeLists.txt
+++ b/Sources/FirebaseAndroid/CMakeLists.txt
@@ -7,3 +7,7 @@ target_include_directories(FirebaseAndroidJNI PUBLIC
 target_link_libraries(FirebaseAndroidJNI PRIVATE
   log)
 
+add_jar(SwiftFirebase
+          Native.java
+        INCLUDE_JARS
+          $ENV{ANDROID_SDK_ROOT}/platforms/android-${ANDROID_NATIVE_API_LEVEL}/android.jar)

--- a/Sources/FirebaseAndroid/Native.java
+++ b/Sources/FirebaseAndroid/Native.java
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+package company.thebrowser;
+
+import android.app.Activity;
+
+public class Native
+{
+  public native boolean RegisterActivity(android.app.Activity activity);
+}


### PR DESCRIPTION
This introduces the Java bindings for the JNI backed implementation. When implementing an Android application which uses swift-firebase, `SwiftFirebase` provides the bridge to the JNI functions required to enable the functionality.