### PR TITLE
FirebaseCore: port to android

### DIFF
--- a/Sources/FirebaseCore/FirebaseApp+Swift.swift
+++ b/Sources/FirebaseCore/FirebaseApp+Swift.swift
@@ -3,19 +3,39 @@
 @_exported
 import firebase
 
+#if os(Android)
+private import FirebaseAndroid
+#endif
+
 public typealias FirebaseApp = UnsafeMutablePointer<firebase.App>
 
 extension FirebaseApp {
   public static func configure() {
+#if os(Android)
+    _ = firebase.App.Create(SwiftFirebase_GetJavaEnvironment(),
+                            SwiftFirebase_GetActivity())
+#else
     _ = firebase.App.Create()
+#endif
   }
 
   public static func configure(options: FirebaseOptions) {
+#if os(Android)
+    _ = firebase.App.Create(options.pointee, SwiftFirebase_GetJavaEnvironment(),
+                            SwiftFirebase_GetActivity())
+#else
     _ = firebase.App.Create(options.pointee)
+#endif
   }
 
   public static func configure(name: String, options: FirebaseOptions) {
+#if os(Android)
+    _ = firebase.App.Create(options.pointee, name,
+                            SwiftFirebase_GetJavaEnvironment(),
+                            SwiftFirebase_GetActivity())
+#else
     _ = firebase.App.Create(options.pointee, name)
+#endif
   }
 
   public static func app() -> FirebaseApp? {

--- a/Sources/FirebaseCore/FirebaseOptions+Swift.swift
+++ b/Sources/FirebaseCore/FirebaseOptions+Swift.swift
@@ -3,6 +3,10 @@
 @_exported
 import firebase
 
+#if os(Android)
+private import FirebaseAndroid
+#endif
+
 import Foundation
 
 public typealias FirebaseOptions = UnsafeMutablePointer<firebase.AppOptions>
@@ -27,7 +31,16 @@ extension firebase.AppOptions: CustomDebugStringConvertible {
 
 extension FirebaseOptions {
   public static func defaultOptions() -> FirebaseOptions {
-    guard let options = firebase.AppOptions.LoadDefault(nil) else {
+#if os(Android)
+    let options =
+        firebase.AppOptions.LoadDefault(nil,
+                                        SwiftFirebase_GetJavaEnvironment(),
+                                        SwiftFirebase_GetActivity())
+#else
+    let options = firebase.AppOptions.LoadDefault(nil)
+#endif
+
+    guard let options else {
       fatalError("unable to deserialise firebase options")
     }
     return options


### PR DESCRIPTION
This adjusts the API usage to account for signature differences on Android. This is the first step towards setting up the android port.