### PR TITLE
FirebaseAndroid: fix & remove nullability annotations

### DIFF
--- a/Sources/FirebaseAndroid/include/FirebaseAndroid.h
+++ b/Sources/FirebaseAndroid/include/FirebaseAndroid.h
@@ -9,9 +9,9 @@
 extern "C" {
 #endif
 
-jobject _Nullable SwiftFirebase_GetActivity(void);
-JNIEnv * _Nullable SwiftFirebase_GetJavaEnvironment(void);
-JavaVM * _Nullable SwiftFirebase_GetJVM(void);
+jobject SwiftFirebase_GetActivity(void);
+JNIEnv *SwiftFirebase_GetJavaEnvironment(void);
+JavaVM *SwiftFirebase_GetJVM(void);
 
 #if defined(__cplusplus)
 }

--- a/Sources/FirebaseAndroid/jni.c
+++ b/Sources/FirebaseAndroid/jni.c
@@ -53,10 +53,10 @@ FIREBASE_ANDROID_ABI
 jint JNI_OnLoad(JavaVM *vm, void *reserved)
 {
   g_VM = vm;
-  if ((*g_VM)->GetEnv(g_VM, (void **)&g_Env, JNI_VERSION_1_6) == JNI_OK)
-    return JNI_VERSION_1_6;
+  if ((*g_VM)->GetEnv(g_VM, (void **)&g_Env, JNI_VERSION_1_6) != JNI_OK)
+    return -1;
   RegisterNativeMethods(g_Env);
-  return -1;
+  return JNI_VERSION_1_6;
 }
 
 FIREBASE_ANDROID_ABI


### PR DESCRIPTION
The nullability annotations seem to cause warnings due to `-Wnullability-completeness`. Correctly annotating the types as `_Nullable JavaVM * _Nonnull` seems to not work across Swift and C/C++. Rather than try to force this, simply avoid the nullability annotations.

Clear up the method registration which was never being invoked due to an early return in the success case.