### PR TITLE
FirebaseFunctions API correctness fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,7 +200,7 @@ target_link_libraries(FirebaseFirestore PUBLIC
   zlibstatic)
 
 add_library(FirebaseFunctions SHARED
-  Sources/FirebaseFunctions/FirebaseFunctionsErrorCode.swift
+  Sources/FirebaseFunctions/FunctionsErrorCode.swift
   Sources/FirebaseFunctions/Functions+Swift.swift
   Sources/FirebaseFunctions/HTTPSCallable+Swift.swift
   Sources/FirebaseFunctions/HTTPSCallableResult+Swift.swift)

--- a/Sources/FirebaseFunctions/FunctionsErrorCode.swift
+++ b/Sources/FirebaseFunctions/FunctionsErrorCode.swift
@@ -5,7 +5,7 @@ import firebase
 @_spi(FirebaseInternal)
 import FirebaseCore
 
-public struct FirebaseFunctionsErrorCode: Error {
+public struct FunctionsErrorCode: Error {
   public let rawValue: Int
   public let localizedDescription: String
 
@@ -19,7 +19,7 @@ public struct FirebaseFunctionsErrorCode: Error {
   }
 }
 
-extension FirebaseFunctionsErrorCode: RawRepresentable {
+extension FunctionsErrorCode: RawRepresentable {
   public typealias RawValue = Int
 
   public init(rawValue: Int) {
@@ -28,7 +28,7 @@ extension FirebaseFunctionsErrorCode: RawRepresentable {
   }
 }
 
-extension FirebaseFunctionsErrorCode {
+extension FunctionsErrorCode {
   init(_ error: firebase.functions.Error, errorMessage: String?) {
     self.init((code: error.rawValue, message: errorMessage ?? "\(error.rawValue)"))
   }
@@ -43,7 +43,7 @@ extension FirebaseFunctionsErrorCode {
   }
 }
 
-extension FirebaseFunctionsErrorCode {
+extension FunctionsErrorCode {
   public static var none: Self { .init(firebase.functions.kErrorNone) }
   public static var cancelled: Self { .init(firebase.functions.kErrorCancelled) }
   public static var unknown: Self { .init(firebase.functions.kErrorUnknown) }
@@ -63,11 +63,11 @@ extension FirebaseFunctionsErrorCode {
   public static var dataLoss: Self { .init(firebase.functions.kErrorDataLoss) }
 }
 
-extension FirebaseFunctionsErrorCode: Equatable {}
+extension FunctionsErrorCode: Equatable {}
 
-extension FirebaseFunctionsErrorCode {
+extension FunctionsErrorCode {
   // The Obj C API provides this type as well, so provide it here for consistency.
-  public typealias Code = FirebaseFunctionsErrorCode
+  public typealias Code = FunctionsErrorCode
 
   // This allows us to re-expose self as a code similarly
   // to what the Firebase SDK does when it creates the

--- a/Sources/FirebaseFunctions/HTTPSCallable+Swift.swift
+++ b/Sources/FirebaseFunctions/HTTPSCallable+Swift.swift
@@ -39,7 +39,7 @@ public class HTTPSCallable {
     let variant = try! toVariant(data)
     let future = swift_firebase.swift_cxx_shims.firebase.functions.https_callable_call(impl, variant)
     future.setCompletion({
-      let (result, error) = future.resultAndError { FirebaseFunctionsErrorCode($0) }
+      let (result, error) = future.resultAndError { FunctionsErrorCode($0) }
       completion(result.map { .init($0) }, error)
     })
   }

--- a/Sources/FirebaseFunctions/HTTPSCallableResult+Swift.swift
+++ b/Sources/FirebaseFunctions/HTTPSCallableResult+Swift.swift
@@ -9,7 +9,7 @@ import CxxShim
 import Foundation
 
 public class HTTPSCallableResult {
-  let data: Any
+  public let data: Any
 
   init(_ result: firebase.functions.HttpsCallableResult = .init()) {
     let variant = swift_firebase.swift_cxx_shims.firebase.functions.https_callable_result_data(result)


### PR DESCRIPTION
Changes:
- Make `HTTPSCallableResult.data` public
- `FirebaseFunctionsErrorCode` should just be `FunctionsErrorCode`