### PR TITLE
Add FirebaseStorage module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,6 +221,7 @@ target_link_libraries(FirebaseFunctions PRIVATE
 add_library(FirebaseStorage SHARED
   Sources/FirebaseStorage/StorageErrorCode.swift
   Sources/FirebaseStorage/Storage+Swift.swift
+  Sources/FirebaseStorage/StorageMetadata+Swift.swift
   Sources/FirebaseStorage/StorageReference+Swift.swift)
 target_compile_options(FirebaseStorage PRIVATE
   -cxx-interoperability-mode=default)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,24 @@ target_link_libraries(FirebaseFunctions PRIVATE
   ssl
   zlibstatic)
 
+add_library(FirebaseStorage SHARED
+  Sources/FirebaseStorage/StorageErrorCode.swift
+  Sources/FirebaseStorage/Storage+Swift.swift
+  Sources/FirebaseStorage/StorageReference+Swift.swift)
+target_compile_options(FirebaseStorage PRIVATE
+  -cxx-interoperability-mode=default)
+target_link_libraries(FirebaseStorage PUBLIC
+  firebase
+  firebase_storage
+  FirebaseCore)
+target_link_libraries(FirebaseStorage PRIVATE
+  crypto
+  firebase_rest_lib
+  flatbuffers
+  libcurl
+  ssl
+  zlibstatic)
+
 if(SWIFT_FIREBASE_BUILD_EXAMPLES)
   FetchContent_Declare(SwiftWin32
     GIT_REPOSITORY https://github.com/compnerd/swift-win32

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,7 @@ let SwiftFirebase =
               .library(name: "FirebaseAuth", targets: ["FirebaseAuth"]),
               .library(name: "FirebaseFirestore", targets: ["FirebaseFirestore"]),
               .library(name: "FirebaseFunctions", targets: ["FirebaseFunctions"]),
+              .library(name: "FirebaseStorage", targets: ["FirebaseStorage"]),
               .executable(name: "FireBaseUI", targets: ["FireBaseUI"]),
             ],
             dependencies: [
@@ -182,6 +183,18 @@ let SwiftFirebase =
                         .linkedLibrary("utf8_validity"),
                       ]),
               .target(name: "FirebaseFunctions",
+                      dependencies: ["firebase", "FirebaseCore"],
+                      cxxSettings: [
+                        .define("INTERNAL_EXPERIMENTAL"),
+                        .define("_CRT_SECURE_NO_WARNINGS",
+                                .when(platforms: [.windows])),
+                        .headerSearchPath("../../third_party/firebase-development/usr/include"),
+                      ],
+                      swiftSettings: [
+                        .interoperabilityMode(.Cxx),
+                        .unsafeFlags(["-Xcc", "-I\(include)"]),
+                      ]),
+              .target(name: "FirebaseStorage",
                       dependencies: ["firebase", "FirebaseCore"],
                       cxxSettings: [
                         .define("INTERNAL_EXPERIMENTAL"),

--- a/Sources/FirebaseFunctions/HTTPSCallable+Swift.swift
+++ b/Sources/FirebaseFunctions/HTTPSCallable+Swift.swift
@@ -28,7 +28,7 @@ public class HTTPSCallable {
       callImpl(data: data) { result, error in
         if let error {
           continuation.resume(throwing: error)
-        } else{
+        } else {
           continuation.resume(returning: result ?? .init())
         }
       }

--- a/Sources/FirebaseStorage/Storage+Swift.swift
+++ b/Sources/FirebaseStorage/Storage+Swift.swift
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+@_exported
+import firebase
+@_spi(FirebaseInternal)
+import FirebaseCore
+
+import CxxShim
+
+public class Storage {
+  let impl: swift_firebase.swift_cxx_shims.firebase.storage.StorageRef
+
+  init(_ impl: swift_firebase.swift_cxx_shims.firebase.storage.StorageRef) {
+    self.impl = impl
+  }
+
+  public static func storage(app: FirebaseApp) -> Storage {
+    let instance = swift_firebase.swift_cxx_shims.firebase.storage.storage_get_instance(app)
+    guard swift_firebase.swift_cxx_shims.firebase.storage.storage_is_valid(instance) else {
+      fatalError("Invalid Storage Instance")
+    }
+    return .init(instance)
+  }
+
+  public func reference(withPath path: String) -> StorageReference {
+    .init(swift_firebase.swift_cxx_shims.firebase.storage.storage_get_reference(impl, path))
+  }
+}

--- a/Sources/FirebaseStorage/StorageErrorCode.swift
+++ b/Sources/FirebaseStorage/StorageErrorCode.swift
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+@_exported
+import firebase
+@_spi(FirebaseInternal)
+import FirebaseCore
+
+public struct StorageErrorCode: Error {
+  public let rawValue: Int
+  public let localizedDescription: String
+
+  internal init(_ params: (code: Int32, message: String)) {
+    self.rawValue = Int(params.code)
+    localizedDescription = params.message
+  }
+
+  private init(_ error: firebase.storage.Error) {
+    self.init(rawValue: Int(error.rawValue))
+  }
+}
+
+extension StorageErrorCode: RawRepresentable {
+  public typealias RawValue = Int
+
+  public init(rawValue: Int) {
+    self.rawValue = rawValue
+    localizedDescription = "\(rawValue)"
+  }
+}
+
+extension StorageErrorCode {
+  init(_ error: firebase.storage.Error, errorMessage: String?) {
+    self.init((code: error.rawValue, message: errorMessage ?? "\(error.rawValue)"))
+  }
+
+  init?(_ error: firebase.storage.Error?, errorMessage: UnsafePointer<CChar>?) {
+    guard let actualError = error, actualError.rawValue != 0 else { return nil }
+    var errorMessageString: String?
+    if let errorMessage {
+      errorMessageString = .init(cString: errorMessage)
+    }
+    self.init(actualError, errorMessage: errorMessageString)
+  }
+}
+
+extension StorageErrorCode {
+  public static var none: Self { .init(firebase.storage.kErrorNone) }
+  public static var unknown: Self { .init(firebase.storage.kErrorUnknown) }
+  public static var objectNotFound: Self { .init(firebase.storage.kErrorObjectNotFound) }
+  public static var bucketNotFound: Self { .init(firebase.storage.kErrorBucketNotFound) }
+  public static var projectNotFound: Self { .init(firebase.storage.kErrorProjectNotFound) }
+  public static var quotaExceeded: Self { .init(firebase.storage.kErrorQuotaExceeded) }
+  public static var unauthenticated: Self { .init(firebase.storage.kErrorUnauthenticated) }
+  public static var unauthorized: Self { .init(firebase.storage.kErrorUnauthorized) }
+  public static var retryLimitExceeded: Self { .init(firebase.storage.kErrorRetryLimitExceeded) }
+  public static var nonMatchingChecksum: Self { .init(firebase.storage.kErrorNonMatchingChecksum) }
+  public static var downloadSizeExceeded: Self { .init(firebase.storage.kErrorDownloadSizeExceeded) }
+  public static var cancelled: Self { .init(firebase.storage.kErrorCancelled) }
+}
+
+extension StorageErrorCode: Equatable {}
+
+extension StorageErrorCode {
+  // The Obj C API provides this type as well, so provide it here for consistency.
+  public typealias Code = StorageErrorCode
+
+  // This allows us to re-expose self as a code similarly
+  // to what the Firebase SDK does when it creates the
+  // underlying NSErrors on iOS/macOS.
+  public var code: Code {
+    return self
+  }
+
+  public init(_ code: Code) {
+    self.init(rawValue: code.rawValue)
+  }
+}

--- a/Sources/FirebaseStorage/StorageMetadata+Swift.swift
+++ b/Sources/FirebaseStorage/StorageMetadata+Swift.swift
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+@_exported
+import firebase
+@_spi(FirebaseInternal)
+import FirebaseCore
+
+import CxxShim
+
+public class StorageMetadata {
+  let impl: firebase.storage.Metadata
+
+  public init() {
+    self.impl = .init()
+  }
+
+  public var customMetadata: [String: String]? {
+    get {
+      let map = swift_firebase.swift_cxx_shims.firebase.storage.metadata_get_custom_metadata(impl)
+      return map.toDict()
+    }
+    //set {
+    //  swift_firebase.swift_cxx_shims.firebase.storage.set_custom_metadata(impl, newValue)
+    //}
+  }
+}
+
+extension swift_firebase.swift_cxx_shims.firebase.storage.CustomMetadata {
+  borrowing func toDict() -> [String: String] {
+    var result = [String: String]()
+    var iterator = swift_firebase.swift_cxx_shims.firebase.storage.custom_metadata_begin(self)
+    let endIterator = swift_firebase.swift_cxx_shims.firebase.storage.custom_metadata_end(self)
+
+    while !swift_firebase.swift_cxx_shims.firebase.storage.custom_metadata_iterators_equal(iterator, endIterator) {
+      let key = swift_firebase.swift_cxx_shims.firebase.storage.custom_metadata_iterator_first(iterator)
+      let value = swift_firebase.swift_cxx_shims.firebase.storage.custom_metadata_iterator_second(iterator)
+      result[String(key.pointee)] = String(value.pointee)
+      iterator = iterator.successor()
+    }
+    return result
+  }
+}

--- a/Sources/FirebaseStorage/StorageMetadata+Swift.swift
+++ b/Sources/FirebaseStorage/StorageMetadata+Swift.swift
@@ -35,6 +35,7 @@ public class StorageMetadata {
   }
 }
 
+// Workaround for https://github.com/apple/swift/issues/69711
 private extension swift_firebase.swift_cxx_shims.firebase.storage.CustomMetadata {
   borrowing func toDict() -> [String: String] {
     var result = [String: String]()

--- a/Sources/FirebaseStorage/StorageMetadata+Swift.swift
+++ b/Sources/FirebaseStorage/StorageMetadata+Swift.swift
@@ -35,7 +35,7 @@ public class StorageMetadata {
   }
 }
 
-extension swift_firebase.swift_cxx_shims.firebase.storage.CustomMetadata {
+private extension swift_firebase.swift_cxx_shims.firebase.storage.CustomMetadata {
   borrowing func toDict() -> [String: String] {
     var result = [String: String]()
     var iterator = swift_firebase.swift_cxx_shims.firebase.storage.custom_metadata_begin(self)

--- a/Sources/FirebaseStorage/StorageMetadata+Swift.swift
+++ b/Sources/FirebaseStorage/StorageMetadata+Swift.swift
@@ -19,9 +19,15 @@ public class StorageMetadata {
       let map = swift_firebase.swift_cxx_shims.firebase.storage.metadata_get_custom_metadata(impl)
       return map.toDict()
     }
-    //set {
-    //  swift_firebase.swift_cxx_shims.firebase.storage.set_custom_metadata(impl, newValue)
-    //}
+    set {
+      swift_firebase.swift_cxx_shims.firebase.storage.metadata_clear_custom_metadata(impl)
+      guard let newValue else { return }
+      for (key, value) in newValue {
+        swift_firebase.swift_cxx_shims.firebase.storage.metadata_insert_custom_metadata(
+          impl, std.string(key), std.string(value)
+        )
+      }
+    }
   }
 }
 

--- a/Sources/FirebaseStorage/StorageMetadata+Swift.swift
+++ b/Sources/FirebaseStorage/StorageMetadata+Swift.swift
@@ -10,6 +10,10 @@ import CxxShim
 public class StorageMetadata {
   let impl: firebase.storage.Metadata
 
+  init(_ impl: firebase.storage.Metadata) {
+    self.impl = impl
+  }
+
   public init() {
     self.impl = .init()
   }

--- a/Sources/FirebaseStorage/StorageReference+Swift.swift
+++ b/Sources/FirebaseStorage/StorageReference+Swift.swift
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+@_exported
+import firebase
+@_spi(FirebaseInternal)
+import FirebaseCore
+
+import CxxShim
+import Foundation
+
+public class StorageReference {
+  let impl: firebase.storage.StorageReference
+
+  init(_ impl: firebase.storage.StorageReference) {
+    self.impl = impl
+  }
+
+  public func child(_ path: String) -> StorageReference {
+    .init(impl.Child(path))
+  }
+
+  public func downloadURL(completion: @escaping (URL?, Error?) -> Void) {
+    downloadURLImpl() { result, error in
+      DispatchQueue.main.async {
+        completion(result, error)
+      }
+    }
+  }
+
+  public func downloadURL() async throws -> URL {
+    try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<URL, any Error>) in
+      downloadURLImpl() { result, error in
+        if let error {
+          continuation.resume(throwing: error)
+        } else {
+          continuation.resume(returning: result!)
+        }
+      }
+    }
+  }
+
+  private func downloadURLImpl(completion: @escaping (URL?, Error?) -> Void) {
+    let future = swift_firebase.swift_cxx_shims.firebase.storage.storage_reference_get_download_url(impl)
+    future.setCompletion({
+      let (result, error) = future.resultAndError { StorageErrorCode($0) }
+      completion(result.flatMap { .init(string: String($0)) }, error)
+    })
+  }
+}

--- a/Sources/firebase/include/FirebaseStorage.hh
+++ b/Sources/firebase/include/FirebaseStorage.hh
@@ -36,8 +36,17 @@ storage_reference_get_download_url(::firebase::storage::StorageReference ref) {
 
 inline ::swift_firebase::swift_cxx_shims::firebase::Future<::firebase::storage::Metadata>
 storage_reference_put_bytes(::firebase::storage::StorageReference ref,
-                            const void* buffer, size_t buffer_size) {
-  return ref.PutBytes(buffer, buffer_size);
+                            const void* buffer, size_t buffer_size,
+                            ::firebase::storage::Controller* controller) {
+  return ref.PutBytes(buffer, buffer_size, nullptr, controller);
+}
+
+inline ::swift_firebase::swift_cxx_shims::firebase::Future<::firebase::storage::Metadata>
+storage_reference_put_bytes(::firebase::storage::StorageReference ref,
+                            const void* buffer, size_t buffer_size,
+                            const ::firebase::storage::Metadata& metadata,
+                            ::firebase::storage::Controller* controller) {
+  return ref.PutBytes(buffer, buffer_size, metadata, nullptr, controller);
 }
 
 typedef std::map<std::string, std::string> CustomMetadata;

--- a/Sources/firebase/include/FirebaseStorage.hh
+++ b/Sources/firebase/include/FirebaseStorage.hh
@@ -29,31 +29,43 @@ storage_get_reference(const StorageRef& ref, const char* path) {
   return ref->GetReference(path);
 }
 
-/*
-inline ::firebase::functions::HttpsCallableReference
-functions_get_https_callable(StorageRef ref, const char* name) {
-  return ref.get()->GetHttpsCallable(name);
-}
-
-inline ::swift_firebase::swift_cxx_shims::firebase::Future<
-    ::firebase::functions::HttpsCallableResult>
-https_callable_call(::firebase::functions::HttpsCallableReference ref) {
-  return ref.Call();
-}
-*/
-
 inline ::swift_firebase::swift_cxx_shims::firebase::Future<::std::string>
 storage_reference_get_download_url(::firebase::storage::StorageReference ref) {
   return ref.GetDownloadUrl();
 }
 
-/*
-inline ::firebase::Variant
-https_callable_result_data(
-    const ::firebase::functions::HttpsCallableResult& result) {
-  return result.data();
+typedef std::map<std::string, std::string> CustomMetadata;
+
+inline CustomMetadata
+metadata_get_custom_metadata(const ::firebase::storage::Metadata& metadata) {
+  return *metadata.custom_metadata();
 }
-*/
+
+inline CustomMetadata::const_iterator
+custom_metadata_begin(const CustomMetadata& custom_metadata) {
+  return custom_metadata.begin();
+}
+
+inline CustomMetadata::const_iterator
+custom_metadata_end(const CustomMetadata& custom_metadata) {
+  return custom_metadata.end();
+}
+
+inline bool
+custom_metadata_iterators_equal(const CustomMetadata::const_iterator& a,
+                                const CustomMetadata::const_iterator& b) {
+  return a == b;
+}
+
+inline const std::string&
+custom_metadata_iterator_first(const CustomMetadata::const_iterator& it) {
+  it->first;
+}
+
+inline const std::string&
+custom_metadata_iterator_second(const CustomMetadata::const_iterator& it) {
+  it->second;
+}
 
 } // namespace swift_firebase::swift_cxx_shims::firebase::functions
 

--- a/Sources/firebase/include/FirebaseStorage.hh
+++ b/Sources/firebase/include/FirebaseStorage.hh
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef firebase_include_FirebaseStorage_hh
+#define firebase_include_FirebaseStorage_hh
+
+#include <memory>
+
+#include <firebase/storage.h>
+#include <firebase/storage/storage_reference.h>
+
+#include "FirebaseCore.hh"
+
+namespace swift_firebase::swift_cxx_shims::firebase::storage {
+
+typedef std::shared_ptr<::firebase::storage::Storage> StorageRef;
+
+inline bool
+storage_is_valid(const StorageRef& ref) {
+  return ref.operator bool();
+}
+
+inline StorageRef
+storage_get_instance(::firebase::App* app) {
+  return StorageRef(::firebase::storage::Storage::GetInstance(app));
+}
+
+inline ::firebase::storage::StorageReference
+storage_get_reference(const StorageRef& ref, const char* path) {
+  return ref->GetReference(path);
+}
+
+/*
+inline ::firebase::functions::HttpsCallableReference
+functions_get_https_callable(StorageRef ref, const char* name) {
+  return ref.get()->GetHttpsCallable(name);
+}
+
+inline ::swift_firebase::swift_cxx_shims::firebase::Future<
+    ::firebase::functions::HttpsCallableResult>
+https_callable_call(::firebase::functions::HttpsCallableReference ref) {
+  return ref.Call();
+}
+*/
+
+inline ::swift_firebase::swift_cxx_shims::firebase::Future<::std::string>
+storage_reference_get_download_url(::firebase::storage::StorageReference ref) {
+  return ref.GetDownloadUrl();
+}
+
+/*
+inline ::firebase::Variant
+https_callable_result_data(
+    const ::firebase::functions::HttpsCallableResult& result) {
+  return result.data();
+}
+*/
+
+} // namespace swift_firebase::swift_cxx_shims::firebase::functions
+
+#endif

--- a/Sources/firebase/include/FirebaseStorage.hh
+++ b/Sources/firebase/include/FirebaseStorage.hh
@@ -67,6 +67,18 @@ custom_metadata_iterator_second(const CustomMetadata::const_iterator& it) {
   it->second;
 }
 
+inline void
+metadata_clear_custom_metadata(const ::firebase::storage::Metadata& metadata) {
+  metadata.custom_metadata()->clear();
+}
+
+inline void
+metadata_insert_custom_metadata(const ::firebase::storage::Metadata& metadata,
+                                const std::string& key,
+                                const std::string& value) {
+  (*metadata.custom_metadata())[key] = value;
+}
+
 } // namespace swift_firebase::swift_cxx_shims::firebase::functions
 
 #endif

--- a/Sources/firebase/include/FirebaseStorage.hh
+++ b/Sources/firebase/include/FirebaseStorage.hh
@@ -34,6 +34,12 @@ storage_reference_get_download_url(::firebase::storage::StorageReference ref) {
   return ref.GetDownloadUrl();
 }
 
+inline ::swift_firebase::swift_cxx_shims::firebase::Future<::firebase::storage::Metadata>
+storage_reference_put_bytes(::firebase::storage::StorageReference ref,
+                            const void* buffer, size_t buffer_size) {
+  return ref.PutBytes(buffer, buffer_size);
+}
+
 typedef std::map<std::string, std::string> CustomMetadata;
 
 inline CustomMetadata

--- a/Sources/firebase/include/module.modulemap
+++ b/Sources/firebase/include/module.modulemap
@@ -35,4 +35,9 @@ module firebase [system] {
     header "FirebaseFunctions.hh"
     export *
   }
+
+  module storage {
+    header "FirebaseStorage.hh"
+    export *
+  }
 }


### PR DESCRIPTION
Adds the subset of `FirebaseStorage` needed by Arc:
- `Storage` (partial)
- `StorageReference` (partial)
- `StorageMetadata` (partial)
- `StorageErrorCode`

The implementation of `StorageMetadata.customMetadata` required some extra thunking through the `CxxShims` lib.