### PR TITLE
FLOW-764: Pass callable reference by value to avoid crash

### DIFF
--- a/Sources/FirebaseFunctions/HTTPSCallable+Swift.swift
+++ b/Sources/FirebaseFunctions/HTTPSCallable+Swift.swift
@@ -9,7 +9,7 @@ import CxxShim
 import Foundation
 
 public class HTTPSCallable {
-  let impl: firebase.functions.HttpsCallableReference
+  var impl: firebase.functions.HttpsCallableReference
 
   init(_ impl: firebase.functions.HttpsCallableReference) {
     self.impl = impl
@@ -37,7 +37,7 @@ public class HTTPSCallable {
 
   private func callImpl(data: Any?, completion: @escaping (HTTPSCallableResult?, Error?) -> Void) {
     let variant = try! toVariant(data)
-    let future = swift_firebase.swift_cxx_shims.firebase.functions.https_callable_call(impl, variant)
+    let future = swift_firebase.swift_cxx_shims.firebase.functions.https_callable_call(&impl, variant)
     future.setCompletion({
       let (result, error) = future.resultAndError { FunctionsErrorCode($0) }
       completion(result.map { .init($0) }, error)

--- a/Sources/firebase/include/FirebaseFunctions.hh
+++ b/Sources/firebase/include/FirebaseFunctions.hh
@@ -30,15 +30,17 @@ functions_get_https_callable(FunctionsRef ref, const char* name) {
   return ref.get()->GetHttpsCallable(name);
 }
 
+// TODO(WPP-2267): Pass HttpsCallableReference by value instead.
 inline ::swift_firebase::swift_cxx_shims::firebase::Future<
     ::firebase::functions::HttpsCallableResult>
-https_callable_call(::firebase::functions::HttpsCallableReference ref) {
+https_callable_call(::firebase::functions::HttpsCallableReference& ref) {
   return ref.Call();
 }
 
+// TODO(WPP-2267): Pass HttpsCallableReference by value instead.
 inline ::swift_firebase::swift_cxx_shims::firebase::Future<
     ::firebase::functions::HttpsCallableResult>
-https_callable_call(::firebase::functions::HttpsCallableReference ref,
+https_callable_call(::firebase::functions::HttpsCallableReference& ref,
                     const ::firebase::Variant& data) {
   return ref.Call(data);
 }


### PR DESCRIPTION
A temporary workaround for crash when calling the firebase functions. Tickets reference in TODO to make it run in the future. Tested by running it locally and confirming that functions are properly executed.