### PR TITLE
[WPP-2267] Avoid HttpsCallableReference copy constructor

### DIFF
--- a/Sources/FirebaseFunctions/HTTPSCallable+Swift.swift
+++ b/Sources/FirebaseFunctions/HTTPSCallable+Swift.swift
@@ -9,9 +9,9 @@ import CxxShim
 import Foundation
 
 public class HTTPSCallable {
-  let impl: firebase.functions.HttpsCallableReference
+  let impl: swift_firebase.swift_cxx_shims.firebase.functions.HttpsCallableRef
 
-  init(_ impl: firebase.functions.HttpsCallableReference) {
+  init(_ impl: swift_firebase.swift_cxx_shims.firebase.functions.HttpsCallableRef) {
     self.impl = impl
   }
 

--- a/Sources/firebase/include/FirebaseFunctions.hh
+++ b/Sources/firebase/include/FirebaseFunctions.hh
@@ -14,6 +14,7 @@
 namespace swift_firebase::swift_cxx_shims::firebase::functions {
 
 typedef std::shared_ptr<::firebase::functions::Functions> FunctionsRef;
+typedef std::shared_ptr<::firebase::functions::HttpsCallableReference> HttpsCallableRef;
 
 inline bool
 functions_is_valid(const FunctionsRef& ref) {
@@ -25,22 +26,30 @@ functions_get_instance(::firebase::App* app) {
   return FunctionsRef(::firebase::functions::Functions::GetInstance(app));
 }
 
-inline ::firebase::functions::HttpsCallableReference
+inline HttpsCallableRef
 functions_get_https_callable(FunctionsRef ref, const char* name) {
-  return ref.get()->GetHttpsCallable(name);
+  // Unfortunately `HttpsCallableReference` does not use internal reference
+  // counting, and as a result, we need to avoid the copy-constructor for
+  // `HttpsCallableReference`. Otherwise, if Swift creates a copy of the object
+  // and deletes that copy, it will result in any pending `Call` being
+  // interrupted or triggering memory corruption in the case that `Call` has
+  // not completed. To avoid this and to prevent Swift from seeing the copy
+  // constructor, wrap with a `std::shared_ptr`.
+  return HttpsCallableRef(new ::firebase::functions::HttpsCallableReference(
+      std::move(ref.get()->GetHttpsCallable(name))));
 }
 
 inline ::swift_firebase::swift_cxx_shims::firebase::Future<
     ::firebase::functions::HttpsCallableResult>
-https_callable_call(::firebase::functions::HttpsCallableReference ref) {
-  return ref.Call();
+https_callable_call(HttpsCallableRef ref) {
+  return ref.get()->Call();
 }
 
 inline ::swift_firebase::swift_cxx_shims::firebase::Future<
     ::firebase::functions::HttpsCallableResult>
-https_callable_call(::firebase::functions::HttpsCallableReference ref,
+https_callable_call(HttpsCallableRef ref,
                     const ::firebase::Variant& data) {
-  return ref.Call(data);
+  return ref.get()->Call(data);
 }
 
 inline ::firebase::Variant


### PR DESCRIPTION
Unfortunately `HttpsCallableReference` does not use internal reference counting, and as a result, we need to avoid the copy-constructor for `HttpsCallableReference`. Otherwise, if Swift creates a copy of the object and deletes that copy, it will result in any pending `Call` being interrupted or triggering memory corruption in the case that `Call` has not completed. To avoid this and to prevent Swift from seeing the copy constructor, wrap with a `std::shared_ptr`.