### PR TITLE
FirebaseAndroid: prefer the `CMAKE_ANDROID_API` variable value

### DIFF
--- a/Sources/FirebaseAndroid/CMakeLists.txt
+++ b/Sources/FirebaseAndroid/CMakeLists.txt
@@ -10,4 +10,4 @@ target_link_libraries(FirebaseAndroidJNI PRIVATE
 add_jar(SwiftFirebase
           Native.java
         INCLUDE_JARS
-          $ENV{ANDROID_SDK_ROOT}/platforms/android-${ANDROID_NATIVE_API_LEVEL}/android.jar)
+          $ENV{ANDROID_SDK_ROOT}/platforms/android-${CMAKE_ANDROID_API}/android.jar)


### PR DESCRIPTION
This switches us to use the documented `CMAKE_ANDROID_API` variable rather than the `ANDROID_NATIVE_API_LEVEL` which is an Android toolchain configuration variable. Hopefully this simplifies building swift-firebase for Android.