### PR TITLE
build: tweak the library search path for firebase-cpp-sdk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,7 @@ target_include_directories(firebase INTERFACE
   third_party/firebase-development/usr/include)
 if(ANDROID)
   target_link_directories(firebase INTERFACE
-    third_party/firebase-development/usr/libs/android
-    third_party/firebase-development/usr/libs/android/deps/app
-    third_party/firebase-development/usr/libs/android/deps/app/external)
+    third_party/firebase-development/usr/libs/android/${CMAKE_ANDROID_ARCH_ABI})
 elseif(WIN32)
   target_link_directories(firebase INTERFACE
     third_party/firebase-development/usr/libs/windows


### PR DESCRIPTION
On Android, we use arch variants to support multiple architecture ABI variants. Adjust the default search path that we compute to include this directory to repair the search of libraries.