### PR TITLE
Firestore: silence a couple of warnings with newer compilers

### DIFF
--- a/Sources/FirebaseFirestore/FirestoreDataConverter.swift
+++ b/Sources/FirebaseFirestore/FirestoreDataConverter.swift
@@ -108,8 +108,8 @@ internal struct FirestoreDataConverter {
       }
 
       return firebase.firestore.FieldValue.Map(map)
-    case is firebase.firestore.FieldValue:
-      return field as! firebase.firestore.FieldValue
+    case let field as firebase.firestore.FieldValue:
+      return field
     default:
       return nil
     }

--- a/Sources/FirebaseFirestore/vendor/Codable/DocumentID.swift
+++ b/Sources/FirebaseFirestore/vendor/Codable/DocumentID.swift
@@ -41,9 +41,7 @@ extension String: DocumentIDWrappable {
 
 extension DocumentReference: DocumentIDWrappable {
   public static func wrap(_ documentReference: DocumentReference) throws -> Self {
-    // Swift complains that values of type DocumentReference cannot be returned
-    // as Self which is nonsensical. The cast forces this to work.
-    return documentReference as! Self
+    return documentReference
   }
 }
 


### PR DESCRIPTION
This simply silences some conversion warnings with newer compilers that were identified when adding Android support.