### PR TITLE
build: make C module dependencies public

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ target_link_libraries(FirebaseCore PRIVATE
   $<$<PLATFORM_ID:Windows>:libcurl>
   $<$<PLATFORM_ID:Windows>:zlibstatic>)
 if(ANDROID)
-  target_link_libraries(FirebaseCore PRIVATE
+  target_link_libraries(FirebaseCore PUBLIC
     FirebaseAndroidJNI)
 endif()
 


### PR DESCRIPTION
`FirebaseAndroidJNI` is a C module dependency. Make this dependency public to allow propagation of include paths for the module definition.