### PR TITLE
Functions: make `FirebaseFunctions` build for Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,11 +209,11 @@ target_link_libraries(FirebaseFunctions PUBLIC
   firebase_functions
   FirebaseCore)
 target_link_libraries(FirebaseFunctions PRIVATE
-  crypto
-  firebase_rest_lib
   flatbuffers
-  ssl
+  $<$<PLATFORM_ID:Windows>:crypto>
+  $<$<PLATFORM_ID:Windows>:firebase_rest_lib>
   $<$<PLATFORM_ID:Windows>:libcurl>
+  $<$<PLATFORM_ID:Windows>:ssl>
   $<$<PLATFORM_ID:Windows>:zlibstatic>)
 
 add_library(FirebaseStorage SHARED

--- a/Sources/FirebaseFunctions/FunctionsErrorCode.swift
+++ b/Sources/FirebaseFunctions/FunctionsErrorCode.swift
@@ -30,7 +30,7 @@ extension FunctionsErrorCode: RawRepresentable {
 
 extension FunctionsErrorCode {
   init(_ error: firebase.functions.Error, errorMessage: String?) {
-    self.init((code: error.rawValue, message: errorMessage ?? "\(error.rawValue)"))
+    self.init((code: numericCast(error.rawValue), message: errorMessage ?? "\(error.rawValue)"))
   }
 
   init?(_ error: firebase.functions.Error?, errorMessage: UnsafePointer<CChar>?) {


### PR DESCRIPTION
Remove some linkage on Android as the libraries are not present. It is unclear if this is underlinking, but for now, this allows us to make progress. Explicitly cast the error value as it is a `DWORD` on Windows and `CInt` on Unix.