### PR TITLE
Storage: make `FirebaseStorage` build for Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,11 +228,11 @@ target_link_libraries(FirebaseStorage PUBLIC
   firebase_storage
   FirebaseCore)
 target_link_libraries(FirebaseStorage PRIVATE
-  crypto
-  firebase_rest_lib
   flatbuffers
-  ssl
+  $<$<PLATFORM_ID:Windows>:crypto>
+  $<$<PLATFORM_ID:Windows>:firebase_rest_lib>
   $<$<PLATFORM_ID:Windows>:libcurl>
+  $<$<PLATFORM_ID:Windows>:ssl>
   $<$<PLATFORM_ID:Windows>:zlibstatic>)
 
 if(SWIFT_FIREBASE_BUILD_EXAMPLES)

--- a/Sources/FirebaseStorage/StorageErrorCode.swift
+++ b/Sources/FirebaseStorage/StorageErrorCode.swift
@@ -30,7 +30,7 @@ extension StorageErrorCode: RawRepresentable {
 
 extension StorageErrorCode {
   init(_ error: firebase.storage.Error, errorMessage: String?) {
-    self.init((code: error.rawValue, message: errorMessage ?? "\(error.rawValue)"))
+    self.init((code: numericCast(error.rawValue), message: errorMessage ?? "\(error.rawValue)"))
   }
 
   init?(_ error: firebase.storage.Error?, errorMessage: UnsafePointer<CChar>?) {


### PR DESCRIPTION
Remove some linkage on Android as the libraries are not present. It is unclear if this is underlinking, but for now, this allows us to make progress. Explicitly cast the error value as it is a `DWORD` on Windows and `CInt` on Unix.