### PR TITLE
[android] workaround for a serialization crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include_directories(SYSTEM ${_SWIFT_INCLUDE_DIR}/include)
 
 add_library(firebase INTERFACE)
 target_compile_options(firebase INTERFACE
-  "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -DSR69711>"
+  "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -DSR69711 -Xcc -DSR74578>"
   "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -DINTERNAL_EXPERIMENTAL>")
 target_include_directories(firebase INTERFACE
   Sources/firebase/include

--- a/Sources/firebase/include/FirebaseCore.hh
+++ b/Sources/firebase/include/FirebaseCore.hh
@@ -35,6 +35,21 @@ class SWIFT_CONFORMS_TO_PROTOCOL(FirebaseCore.FutureProtocol)
           completion(user_data);
         });
   }
+
+  // FIXME: Remove once https://github.com/apple/swift/issues/74578 is fixed.
+#if defined(SR74578)
+  int error() const {
+    return ::firebase::Future<R>::error();
+  }
+
+  const R *result() const {
+    return ::firebase::Future<R>::result();
+  }
+
+  const char *error_message() const {
+    return ::firebase::Future<R>::error_message();
+  }
+#endif
 };
 
 // As a workaround, use `int` here instead of `void` for futures with no


### PR DESCRIPTION
Crash is tracked by: https://github.com/apple/swift/issues/74578