### PR TITLE
build: avoid underlinking `FirebaseCore` on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(FirebaseCore PUBLIC
 target_link_libraries(FirebaseCore PRIVATE
   firebase_app
   flatbuffers
+  $<$<PLATFORM_ID:ANDROID>:log>
   $<$<PLATFORM_ID:Windows>:libcurl>
   $<$<PLATFORM_ID:Windows>:zlibstatic>)
 if(ANDROID)


### PR DESCRIPTION
There is an undefined reference to liblog symbols when building for Android. Ensure that we are fulfilling all the requirements when linking the DSO.