### PR TITLE
build: correct platform spelling to ensure linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ target_link_libraries(FirebaseCore PUBLIC
 target_link_libraries(FirebaseCore PRIVATE
   firebase_app
   flatbuffers
-  $<$<PLATFORM_ID:ANDROID>:log>
+  $<$<PLATFORM_ID:Android>:log>
   $<$<PLATFORM_ID:Windows>:libcurl>
   $<$<PLATFORM_ID:Windows>:zlibstatic>)
 if(ANDROID)


### PR DESCRIPTION
The platform identifier spelling is case sensitive and we would fail to link to `liblog` resulting in underlinking. This corrects the spelling and underlinking as a consequence.