### PR TITLE
FirebaseAndroid: correct printf conversion specifier

### DIFF
--- a/Sources/FirebaseAndroid/jni.c
+++ b/Sources/FirebaseAndroid/jni.c
@@ -46,7 +46,7 @@ RegisterNativeMethods(JNIEnv *env)
     LOG_ERROR("JVM.RegisterNatives(%s): %u", kClassPath, result);
     return;
   }
-  LOG_DEBUG("registered %u methods", N_ELEMENTS(kMethods));
+  LOG_DEBUG("registered %lu methods", N_ELEMENTS(kMethods));
 }
 
 FIREBASE_ANDROID_ABI


### PR DESCRIPTION
Use `%lu` to ensure that the parameter is converted properly as per clang.