### PR TITLE
GHA: update actions to v4 (NFCI)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           tag: ${{ matrix.tag }}
           branch: ${{ matrix.branch }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4 # v1.1.1
         with:
@@ -61,7 +61,7 @@ jobs:
           tag: ${{ matrix.tag }}
           branch: ${{ matrix.branch }}
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: dsaltares/fetch-gh-release-asset@a40c8b4a0471f9ab81bdf73a010f74cc51476ad4 # v1.1.1
         with:


### PR DESCRIPTION
Update to the latest version of `actions/checkout` to avoid a deprecation warning.