### PR TITLE
build: use `FindJNI` to locate required headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(swift-firebase
 if(ANDROID)
   enable_language(C)
   include(FindJava)
+  include(FindJNI)
   include(UseJava)
 endif()
 

--- a/Sources/FirebaseAndroid/CMakeLists.txt
+++ b/Sources/FirebaseAndroid/CMakeLists.txt
@@ -5,7 +5,8 @@ add_library(FirebaseAndroidJNI SHARED
 target_include_directories(FirebaseAndroidJNI PUBLIC
   include)
 target_link_libraries(FirebaseAndroidJNI PRIVATE
-  log)
+  log
+  JNI::JNI)
 
 add_jar(SwiftFirebase
           Native.java


### PR DESCRIPTION
We use `jni.h` for the android support library. Setup the search in CMake to allow us to find the header and include the header search path properly.